### PR TITLE
Improved Manual Mode

### DIFF
--- a/app/ui/image_viewer.py
+++ b/app/ui/image_viewer.py
@@ -81,7 +81,9 @@ class ImageViewer(QtWidgets.QGraphicsView):
 
     def handlePanGesture(self, gesture):
         delta = gesture.delta()
-        new_pos = self._last_pan_pos + delta
+        # Supported signatures:
+        # PySide6.QtCore.QPoint.__add__(PySide6.QtCore.QPoint)
+        new_pos = self._last_pan_pos + delta.toPoint()
         
         self.horizontalScrollBar().setValue(
             self.horizontalScrollBar().value() - (new_pos.x() - self._last_pan_pos.x())

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -345,6 +345,7 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
 
         self.brush_size_slider = MSlider()
         self.eraser_size_slider = MSlider()
+        self.min_font_size_slider = MSlider()
 
         self.brush_size_slider.setMinimum(1)
         self.brush_size_slider.setMaximum(50)
@@ -355,8 +356,15 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         self.eraser_size_slider.setMaximum(50)
         self.eraser_size_slider.setValue(20)
         self.eraser_size_slider.valueChanged.connect(self.set_eraser_size)
+
+        self.min_font_size_slider.setMinimum(1)
+        self.min_font_size_slider.setMaximum(50)
+        self.min_font_size_slider.setValue(10)
+        self.min_font_size_slider.valueChanged.connect(self.set_min_font_size)
+
         b_slider_label = MLabel(self.tr("Brush Size Slider"))
         e_slider_label = MLabel(self.tr("Eraser Size Slider"))
+        f_slider_label = MLabel(self.tr("Min Font Size Slider"))
 
         # For returning an Image
         return_buttons_lay = QtWidgets.QHBoxLayout()
@@ -382,6 +390,8 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         tools_layout.addWidget(self.brush_size_slider)
         tools_layout.addWidget(e_slider_label)
         tools_layout.addWidget(self.eraser_size_slider)
+        tools_layout.addWidget(f_slider_label)
+        tools_layout.addWidget(self.min_font_size_slider)
         tools_layout.addLayout(return_buttons_lay)
 
         tools_scroll = QtWidgets.QScrollArea()
@@ -390,7 +400,7 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         tools_scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         tools_scroll.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         tools_scroll.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
-        tools_scroll.setMinimumHeight(300)
+        tools_scroll.setMinimumHeight(400)
 
         right_layout.addLayout(input_layout)
         right_layout.addWidget(tools_scroll)
@@ -518,6 +528,10 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
             h, w, c = image.shape
             scaled_size = self.scale_size(size, w, h)
             self.image_viewer.set_eraser_size(scaled_size)
+
+    def set_min_font_size(self, size: int):
+        None
+        
 
     def scale_size(self, base_size, image_width, image_height):
         # Calculate the diagonal of the image

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -350,7 +350,6 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
 
         self.brush_size_slider = MSlider()
         self.eraser_size_slider = MSlider()
-        self.min_font_size_slider = MSlider()
 
         self.brush_size_slider.setMinimum(1)
         self.brush_size_slider.setMaximum(50)
@@ -361,15 +360,8 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         self.eraser_size_slider.setMaximum(50)
         self.eraser_size_slider.setValue(20)
         self.eraser_size_slider.valueChanged.connect(self.set_eraser_size)
-
-        self.min_font_size_slider.setMinimum(1)
-        self.min_font_size_slider.setMaximum(50)
-        self.min_font_size_slider.setValue(10)
-        self.min_font_size_slider.valueChanged.connect(self.set_min_font_size)
-
         b_slider_label = MLabel(self.tr("Brush Size Slider"))
         e_slider_label = MLabel(self.tr("Eraser Size Slider"))
-        f_slider_label = MLabel(self.tr("Min Font Size Slider"))
 
         # For returning an Image
         return_buttons_lay = QtWidgets.QHBoxLayout()
@@ -395,8 +387,6 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         tools_layout.addWidget(self.brush_size_slider)
         tools_layout.addWidget(e_slider_label)
         tools_layout.addWidget(self.eraser_size_slider)
-        tools_layout.addWidget(f_slider_label)
-        tools_layout.addWidget(self.min_font_size_slider)
         tools_layout.addLayout(return_buttons_lay)
 
         tools_scroll = QtWidgets.QScrollArea()
@@ -405,7 +395,7 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         tools_scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         tools_scroll.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         tools_scroll.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
-        tools_scroll.setMinimumHeight(400)
+        tools_scroll.setMinimumHeight(300)
 
         right_layout.addLayout(input_layout)
         right_layout.addWidget(tools_scroll)
@@ -533,10 +523,6 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
             h, w, c = image.shape
             scaled_size = self.scale_size(size, w, h)
             self.image_viewer.set_eraser_size(scaled_size)
-
-    def set_min_font_size(self, size: int):
-        None
-        
 
     def scale_size(self, base_size, image_width, image_height):
         # Calculate the diagonal of the image

--- a/app/ui/settings/settings_page.py
+++ b/app/ui/settings/settings_page.py
@@ -301,5 +301,11 @@ class SettingsPage(QtWidgets.QWidget):
         msg_box.setStandardButtons(QtWidgets.QMessageBox.Ok)
         msg_box.exec()
 
+    def get_min_font_size(self):
+        return int(self.ui.min_font_spinbox.value())
+    
+    def get_max_font_size(self):
+        return int(self.ui.max_font_spinbox.value())
+
 
 

--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -460,6 +460,29 @@ class SettingsPageUI(QtWidgets.QWidget):
         font_layout = QtWidgets.QVBoxLayout()
         combo_layout = QtWidgets.QHBoxLayout()
 
+        min_font_layout = QtWidgets.QHBoxLayout()
+        max_font_layout = QtWidgets.QHBoxLayout()
+        min_font_label = MLabel(self.tr("Minimum Font Size:"))
+        max_font_label = MLabel(self.tr("Maximum Font Size:"))
+
+        self.min_font_spinbox = MSpinBox().small()
+        self.min_font_spinbox.setFixedWidth(60)
+        self.min_font_spinbox.setMaximum(100)
+        self.min_font_spinbox.setValue(10)
+
+        self.max_font_spinbox = MSpinBox().small()
+        self.max_font_spinbox.setFixedWidth(60)
+        self.max_font_spinbox.setMaximum(100)
+        self.max_font_spinbox.setValue(40)
+
+        min_font_layout.addWidget(min_font_label)
+        min_font_layout.addWidget(self.min_font_spinbox)
+        min_font_layout.addStretch()
+
+        max_font_layout.addWidget(max_font_label)
+        max_font_layout.addWidget(self.max_font_spinbox)
+        max_font_layout.addStretch()
+
         font_label = MLabel(self.tr("Font")).h4()
         self.font_combo = MComboBox().small()
         font_folder_path = os.path.join(os.getcwd(), "fonts")
@@ -477,6 +500,8 @@ class SettingsPageUI(QtWidgets.QWidget):
 
         font_layout.addWidget(font_label)
         font_layout.addLayout(combo_layout)
+        font_layout.addLayout(min_font_layout)
+        font_layout.addLayout(max_font_layout)
 
         text_rendering_layout.addSpacing(10)
         text_rendering_layout.addLayout(font_layout)

--- a/comic.py
+++ b/comic.py
@@ -411,7 +411,7 @@ class ComicTranslate(ComicTranslateUI):
             self.clear_text_edits()
             self.set_tool('brush')
             self.disable_hbutton_group()
-            # self.image_viewer.clear_rectangles()
+            self.image_viewer.clear_rectangles()
             if self.blk_list:
                 for blk in self.blk_list:
                     segm_pts = blk.segm_pts
@@ -459,7 +459,6 @@ class ComicTranslate(ComicTranslateUI):
                     self.current_history_index[file_path] = current_index
                     self.image_data[file_path] = cv2_img
                     self.image_viewer.display_cv2_image(cv2_img)
-                    self.pipeline.load_box_coords(self.blk_list)
                     break
 
     def redo_image(self):
@@ -473,7 +472,6 @@ class ComicTranslate(ComicTranslateUI):
                     self.current_history_index[file_path] = current_index
                     self.image_data[file_path] = cv2_img
                     self.image_viewer.display_cv2_image(cv2_img)
-                    self.pipeline.load_box_coords(self.blk_list)
                     break
 
     def update_blk_list(self):
@@ -571,7 +569,6 @@ class ComicTranslate(ComicTranslateUI):
 
     def on_render_complete(self, rendered_image: np.ndarray):
         self.set_cv2_image(rendered_image)
-        self.pipeline.load_box_coords(self.blk_list)
         self.loading.setVisible(False)
         self.enable_hbutton_group()
 
@@ -594,9 +591,11 @@ class ComicTranslate(ComicTranslateUI):
             target_lang_en = self.lang_mapping.get(target_lang, None)
             trg_lng_cd = get_language_code(target_lang_en)
             format_translations(self.blk_list, trg_lng_cd, upper_case=upper)
+            min_font_size = self.settings_page.get_min_font_size() 
+            max_font_size = self.settings_page.get_max_font_size()
 
             self.run_threaded(draw_text, self.on_render_complete, self.default_error_handler, 
-                              None, inpaint_image, self.blk_list, font_path, 40, colour=font_color, min_font_size=self.min_font_size_slider.value())
+                              None, inpaint_image, self.blk_list, font_path, max_font_size, colour=font_color, min_font_size=min_font_size)
             
     def handle_rectangle_change(self, new_rect: QtCore.QRectF):
         # Find the corresponding TextBlock in blk_list
@@ -659,7 +658,8 @@ class ComicTranslate(ComicTranslateUI):
         # Save brush and eraser sizes
         settings.setValue("brush_size", self.brush_size_slider.value())
         settings.setValue("eraser_size", self.eraser_size_slider.value())
-        settings.setValue("min_font_size", self.min_font_size_slider.value())
+        settings.setValue("min_font_size", self.settings_page.ui.min_font_spinbox.value())
+        settings.setValue("max_font_size", self.settings_page.ui.max_font_spinbox.value())
         
         settings.endGroup()
 
@@ -693,9 +693,11 @@ class ComicTranslate(ComicTranslateUI):
         brush_size = settings.value("brush_size", 10)  # Default value is 10
         eraser_size = settings.value("eraser_size", 20)  # Default value is 20
         min_font_size = settings.value("min_font_size", 10)  # Default value is 10
+        max_font_size = settings.value("max_font_size", 40) # Default value is 40
         self.brush_size_slider.setValue(int(brush_size))
         self.eraser_size_slider.setValue(int(eraser_size))
-        self.min_font_size_slider.setValue(int(min_font_size))
+        self.settings_page.ui.min_font_spinbox.setValue(int(min_font_size))
+        self.settings_page.ui.max_font_spinbox.setValue(int(max_font_size))
 
         settings.endGroup()
 

--- a/comic.py
+++ b/comic.py
@@ -658,8 +658,8 @@ class ComicTranslate(ComicTranslateUI):
         # Save brush and eraser sizes
         settings.setValue("brush_size", self.brush_size_slider.value())
         settings.setValue("eraser_size", self.eraser_size_slider.value())
-        settings.setValue("min_font_size", self.settings_page.ui.min_font_spinbox.value())
-        settings.setValue("max_font_size", self.settings_page.ui.max_font_spinbox.value())
+        settings.setValue("min_font_size", self.settings_page.get_min_font_size())
+        settings.setValue("max_font_size", self.settings_page.get_max_font_size())
         
         settings.endGroup()
 

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -23,7 +23,7 @@ def pil_to_cv2(pil_image: Image):
     
     return cv2_image
 
-def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_size, text: str, roi_width, roi_height, align: str, spacing, min_font_size=10):
+def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, text: str, roi_width, roi_height, align: str, spacing, init_font_size: int = 40, min_font_size=10):
     """Break long text to multiple lines, and reduce point size
     until all text fits within a bounding box."""
     mutable_message = text

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -23,7 +23,7 @@ def pil_to_cv2(pil_image: Image):
     
     return cv2_image
 
-def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, text: str, roi_width, roi_height, align: str, spacing, init_font_size: int = 40, min_font_size=10):
+def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_size, text: str, roi_width, roi_height, align: str, spacing, min_font_size=10):
     """Break long text to multiple lines, and reduce point size
     until all text fits within a bounding box."""
     mutable_message = text

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -86,7 +86,7 @@ def draw_text(image: np.ndarray, blk_list: List[TextBlock], font_pth: str, init_
     font = ImageFont.truetype(font_pth, size=init_font_size)
 
     for blk in blk_list:
-        x1, y1, width, height = blk.xywh()
+        x1, y1, width, height = blk.xywh
         tbbox_top_left = (x1, y1)
 
         translation = blk.translation

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -23,7 +23,7 @@ def pil_to_cv2(pil_image: Image):
     
     return cv2_image
 
-def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_size, text: str, roi_width, roi_height, align: str, spacing):
+def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_size, text: str, roi_width, roi_height, align: str, spacing, min_font_size=10):
     """Break long text to multiple lines, and reduce point size
     until all text fits within a bounding box."""
     mutable_message = text
@@ -35,7 +35,7 @@ def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_
         (left, top, right, bottom) = ImageDraw.Draw(image).multiline_textbbox(xy=tbbox_top_left, text=txt, font=font, align=align, spacing=spacing)
         return (right-left, bottom-top)
 
-    while font_size > 1:
+    while font_size > min_font_size:
         font = font.font_variant(size=font_size)
         width, height = eval_metrics(mutable_message, font)
         if height > roi_height:
@@ -57,9 +57,29 @@ def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_
         else:
             break
 
+    if font_size <= min_font_size:
+        font_size = min_font_size
+        mutable_message = text
+        font = font.font_variant(size=font_size)
+
+        # Wrap text to fit within as much as possible
+        # Minimize cost function: (width - roi_width)^2 + (height - roi_height)^2
+        # This is a brute force approach, but it works well enough
+        min_cost = 1e9
+        min_text = text
+        for columns in range(1, len(text)):
+            wrapped_text = '\n'.join(hyphen_wrap(text, columns, break_on_hyphens=False, break_long_words=False, hyphenate_broken_words=True))
+            wrapped_width, wrapped_height = eval_metrics(wrapped_text, font)
+            cost = (wrapped_width - roi_width)**2 + (wrapped_height - roi_height)**2
+            if cost < min_cost:
+                min_cost = cost
+                min_text = wrapped_text
+
+        mutable_message = min_text
+
     return mutable_message, font_size
 
-def draw_text(image: np.ndarray, blk_list: List[TextBlock], font_pth: str, init_font_size, colour: str = "#000"):
+def draw_text(image: np.ndarray, blk_list: List[TextBlock], font_pth: str, init_font_size, colour: str = "#000", min_font_size=10):
     image = cv2_to_pil(image)
     draw = ImageDraw.Draw(image)
 
@@ -73,7 +93,7 @@ def draw_text(image: np.ndarray, blk_list: List[TextBlock], font_pth: str, init_
         if not translation or len(translation) == 1:
             continue
 
-        translation, font_size = pil_word_wrap(image, tbbox_top_left, font_pth, init_font_size, translation, width, height, align=blk.alignment, spacing=blk.line_spacing)
+        translation, font_size = pil_word_wrap(image, tbbox_top_left, font_pth, init_font_size, translation, width, height, align=blk.alignment, spacing=blk.line_spacing, min_font_size=min_font_size)
         font = font.font_variant(size=font_size)
 
         # Font Detection Workaround. Draws white color offset around text

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -79,7 +79,7 @@ def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_
 
     return mutable_message, font_size
 
-def draw_text(image: np.ndarray, blk_list: List[TextBlock], font_pth: str, init_font_size, colour: str = "#000", min_font_size=10):
+def draw_text(image: np.ndarray, blk_list: List[TextBlock], font_pth: str, colour: str = "#000", init_font_size: int = 40, min_font_size=10):
     image = cv2_to_pil(image)
     draw = ImageDraw.Draw(image)
 

--- a/modules/rendering/render.py
+++ b/modules/rendering/render.py
@@ -23,7 +23,8 @@ def pil_to_cv2(pil_image: Image):
     
     return cv2_image
 
-def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, init_font_size, text: str, roi_width, roi_height, align: str, spacing, min_font_size=10):
+def pil_word_wrap(image: Image, tbbox_top_left: Tuple, font_pth: str, text: str, 
+                  roi_width, roi_height, align: str, spacing, init_font_size: int, min_font_size: int = 10):
     """Break long text to multiple lines, and reduce point size
     until all text fits within a bounding box."""
     mutable_message = text
@@ -93,7 +94,8 @@ def draw_text(image: np.ndarray, blk_list: List[TextBlock], font_pth: str, colou
         if not translation or len(translation) == 1:
             continue
 
-        translation, font_size = pil_word_wrap(image, tbbox_top_left, font_pth, init_font_size, translation, width, height, align=blk.alignment, spacing=blk.line_spacing, min_font_size=min_font_size)
+        translation, font_size = pil_word_wrap(image, tbbox_top_left, font_pth, translation, width, height, 
+                                               align=blk.alignment, spacing=blk.line_spacing, init_font_size=init_font_size, min_font_size=min_font_size)
         font = font.font_variant(size=font_size)
 
         # Font Detection Workaround. Draws white color offset around text

--- a/modules/utils/textblock.py
+++ b/modules/utils/textblock.py
@@ -37,6 +37,7 @@ class TextBlock(object):
         self.source_lang = source_lang
         self.target_lang = target_lang
 
+    @property
     def xywh(self):
         x1, y1, x2, y2 = self.xyxy
         return np.array([x1, y1, x2-x1, y2-y1]).astype(np.int32)

--- a/modules/utils/textblock.py
+++ b/modules/utils/textblock.py
@@ -37,17 +37,17 @@ class TextBlock(object):
         self.source_lang = source_lang
         self.target_lang = target_lang
 
-    @cached_property
+    @property
     def xywh(self):
         x1, y1, x2, y2 = self.xyxy
         return np.array([x1, y1, x2-x1, y2-y1]).astype(np.int32)
 
-    @cached_property
+    @property
     def center(self) -> np.ndarray:
         xyxy = np.array(self.xyxy)
         return (xyxy[:2] + xyxy[2:]) / 2
     
-    @cached_property
+    @property
     def source_lang_direction(self):
         if self.source_lang == 'ja':
             return 'ver_rtl'

--- a/pipeline.py
+++ b/pipeline.py
@@ -294,7 +294,7 @@ class ComicTranslatePipeline:
             max_font_size = self.main_page.settings_page.get_max_font_size()
             min_font_size = self.main_page.settings_page.get_min_font_size()
 
-            rendered_image = draw_text(inpaint_input_img, blk_list, font_path, max_font_size, colour=font_color, min_font_size=min_font_size)
+            rendered_image = draw_text(inpaint_input_img, blk_list, font_path, colour=font_color, init_font_size=max_font_size, min_font_size=min_font_size)
 
             self.main_page.progress_update.emit(index, total_images, 9, 10, False)
             if self.main_page.current_worker and self.main_page.current_worker.is_cancelled:

--- a/pipeline.py
+++ b/pipeline.py
@@ -291,7 +291,10 @@ class ComicTranslatePipeline:
             font_path = f'fonts/{font}'
             set_alignment(blk_list, settings_page)
 
-            rendered_image = draw_text(inpaint_input_img, blk_list, font_path, 40, colour=font_color)
+            max_font_size = self.main_page.settings_page.get_max_font_size()
+            min_font_size = self.main_page.settings_page.get_min_font_size()
+
+            rendered_image = draw_text(inpaint_input_img, blk_list, font_path, max_font_size, colour=font_color, min_font_size=min_font_size)
 
             self.main_page.progress_update.emit(index, total_images, 9, 10, False)
             if self.main_page.current_worker and self.main_page.current_worker.is_cancelled:


### PR DESCRIPTION
Thought I might share some improvements I've made to my own copy to improve the manual translating experience.

## New Features
1. Blocks are rendered even if you undo/redo the image
2. get_best_render_area is disabled for manual mode because it moves block positions. This is not ideal as it will undo manually correctly placed block from an earlier step.
3. Reworked font renderer to now accept a minimum font size. A slider controls it. TODO: add it for automatic mode and use a text field.

## Bug fixes
1. Fixed pan gesture by using `delta.toPoint()` to convert to a qpoint before adding.
2. Rectangle objects on the screen are now cleared when blk_list is reloaded (fixes ghost rectangles).

## Performance Improvements
1. Most models are now cached after initial run. This increases processing speed, especially OCR, manyfold.