### PR TITLE
Decrease and increase all blocks by one button

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1,6 +1,7 @@
 import os
 from PySide6 import QtWidgets
 from PySide6 import QtCore
+from PySide6.QtGui import QIntValidator
 
 from .dayu_widgets import dayu_theme
 from .dayu_widgets.divider import MDivider
@@ -319,13 +320,23 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         box_tools_lay.addWidget(self.clear_rectangles_button)
         box_tools_lay.addWidget(self.draw_blklist_blks)
 
-        self.change_all_blocks_size_dec = self.create_tool_button(svg = "minus_line.svg")
+        self.change_all_blocks_size_dec = self.create_tool_button(svg="minus_line.svg")
         self.change_all_blocks_size_dec.setToolTip(self.tr("Reduce the size of all blocks"))
+        
         self.change_all_blocks_size_diff = MLineEdit()
         self.change_all_blocks_size_diff.setFixedWidth(30)
         self.change_all_blocks_size_diff.setText("3")
-        self.change_all_blocks_size_inc = self.create_tool_button(svg = "add_line.svg")
+        
+        # Set up integer validator
+        int_validator = QIntValidator()
+        self.change_all_blocks_size_diff.setValidator(int_validator)
+        
+        # Optional: Ensure the text is center-aligned
+        self.change_all_blocks_size_diff.setAlignment(QtCore.Qt.AlignCenter)
+        
+        self.change_all_blocks_size_inc = self.create_tool_button(svg="add_line.svg")
         self.change_all_blocks_size_inc.setToolTip(self.tr("Increase the size of all blocks"))
+        
         box_tools_lay.addStretch()
         box_tools_lay.addWidget(self.change_all_blocks_size_dec)
         box_tools_lay.addWidget(self.change_all_blocks_size_diff)

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -6,6 +6,7 @@ from .dayu_widgets import dayu_theme
 from .dayu_widgets.divider import MDivider
 from .dayu_widgets.combo_box import MComboBox
 from .dayu_widgets.text_edit import MTextEdit
+from .dayu_widgets.line_edit import MLineEdit
 from .dayu_widgets.browser import MDragFileButton, MClickBrowserFileToolButton, MClickSaveFileToolButton
 from .dayu_widgets.push_button import MPushButton
 from .dayu_widgets.tool_button import MToolButton
@@ -317,6 +318,18 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         box_tools_lay.addWidget(self.delete_button)
         box_tools_lay.addWidget(self.clear_rectangles_button)
         box_tools_lay.addWidget(self.draw_blklist_blks)
+
+        self.change_all_blocks_size_dec = self.create_tool_button(svg = "minus_line.svg")
+        self.change_all_blocks_size_dec.setToolTip(self.tr("Reduce the size of all blocks"))
+        self.change_all_blocks_size_diff = MLineEdit()
+        self.change_all_blocks_size_diff.setFixedWidth(30)
+        self.change_all_blocks_size_diff.setText("3")
+        self.change_all_blocks_size_inc = self.create_tool_button(svg = "add_line.svg")
+        self.change_all_blocks_size_inc.setToolTip(self.tr("Increase the size of all blocks"))
+        box_tools_lay.addStretch()
+        box_tools_lay.addWidget(self.change_all_blocks_size_dec)
+        box_tools_lay.addWidget(self.change_all_blocks_size_diff)
+        box_tools_lay.addWidget(self.change_all_blocks_size_inc)
         box_tools_lay.addStretch()
 
         # Inpainting Tools

--- a/comic.py
+++ b/comic.py
@@ -99,6 +99,8 @@ class ComicTranslate(ComicTranslateUI):
         self.clear_rectangles_button.clicked.connect(self.image_viewer.clear_rectangles)
         self.clear_brush_strokes_button.clicked.connect(self.image_viewer.clear_brush_strokes)
         self.draw_blklist_blks.clicked.connect(lambda: self.pipeline.load_box_coords(self.blk_list))
+        self.change_all_blocks_size_dec.clicked.connect(lambda: self.change_all_blocks_size(-int(self.change_all_blocks_size_diff.text())))
+        self.change_all_blocks_size_inc.clicked.connect(lambda: self.change_all_blocks_size(int(self.change_all_blocks_size_diff.text())))
 
         # Connect text edit widgets
         self.s_text_edit.textChanged.connect(self.update_text_block)
@@ -125,6 +127,17 @@ class ComicTranslate(ComicTranslateUI):
         for image_path in self.image_files:
             self.image_states[image_path]['source_lang'] = source_lang
             self.image_states[image_path]['target_lang'] = target_lang
+
+    def change_all_blocks_size(self, diff: int):
+        if len(self.blk_list) == 0:
+            return
+        updated_blk_list = []
+        for blk in self.blk_list:
+            blk_rect = tuple(blk.xyxy)
+            blk.xyxy[:] = [blk_rect[0] - diff, blk_rect[1] - diff, blk_rect[2] + diff, blk_rect[3] + diff]
+            updated_blk_list.append(blk)
+        self.blk_list = updated_blk_list
+        self.pipeline.load_box_coords(self.blk_list)
 
     def batch_mode_selected(self):
         self.disable_hbutton_group()


### PR DESCRIPTION
It is very necessary to slightly change the size of all blocks at once before inserting the text so that the text fits inside

![image](https://github.com/user-attachments/assets/14178976-c30c-40b8-81b6-10f0eb89515e)
