### PR TITLE
Save the image and translation stage during auto mode

### DIFF
--- a/comic.py
+++ b/comic.py
@@ -511,8 +511,7 @@ class ComicTranslate(ComicTranslateUI):
 
     def display_image(self, index: int):
         if 0 <= index < len(self.image_files):
-            if self.manual_radio.isChecked():
-                self.save_current_image_state()
+            self.save_current_image_state()
             self.current_image_index = index
             file_path = self.image_files[index]
             

--- a/comic.py
+++ b/comic.py
@@ -511,7 +511,8 @@ class ComicTranslate(ComicTranslateUI):
 
     def display_image(self, index: int):
         if 0 <= index < len(self.image_files):
-            # self.save_current_image_state()
+            if self.manual_radio.isChecked():
+                self.save_current_image_state()
             self.current_image_index = index
             file_path = self.image_files[index]
             

--- a/comic.py
+++ b/comic.py
@@ -511,7 +511,7 @@ class ComicTranslate(ComicTranslateUI):
 
     def display_image(self, index: int):
         if 0 <= index < len(self.image_files):
-            self.save_current_image_state()
+            # self.save_current_image_state()
             self.current_image_index = index
             file_path = self.image_files[index]
             

--- a/pipeline.py
+++ b/pipeline.py
@@ -315,9 +315,13 @@ class ComicTranslatePipeline:
             self.main_page.image_processed.emit(index, rendered_image, image_path)
 
             # Saving blocks with texts to history
-            self.main_page.blk_list = blk_list
-            self.main_page.save_image_state(image_path)
+            self.main_page.image_states[image_path].update({
+                'blk_list': blk_list                   
+            })
 
+            if index == self.main_page.current_image_index:
+                self.main_page.blk_list = blk_list
+                
             render_save_dir = os.path.join(directory, f"comic_translate_{timestamp}", "translated_images", archive_bname)
             if not os.path.exists(render_save_dir):
                 os.makedirs(render_save_dir, exist_ok=True)

--- a/pipeline.py
+++ b/pipeline.py
@@ -230,7 +230,11 @@ class ComicTranslatePipeline:
                 break
 
             inpaint_input_img = self.inpainter_cache(image, mask, config)
-            inpaint_input_img = cv2.convertScaleAbs(inpaint_input_img) 
+            inpaint_input_img = cv2.convertScaleAbs(inpaint_input_img)
+
+            # Saving cleaned image
+            self.main_page.update_image_history(image_path, inpaint_input_img)
+
             inpaint_input_img = cv2.cvtColor(inpaint_input_img, cv2.COLOR_BGR2RGB)
 
             if export_settings['export_inpainted_image']:
@@ -309,7 +313,11 @@ class ComicTranslatePipeline:
 
             # Display or set the rendered Image on the viewer once it's done
             self.main_page.image_processed.emit(index, rendered_image, image_path)
-            
+
+            # Saving blocks with texts to history
+            self.main_page.blk_list = blk_list
+            self.main_page.save_image_state(image_path)
+
             render_save_dir = os.path.join(directory, f"comic_translate_{timestamp}", "translated_images", archive_bname)
             if not os.path.exists(render_save_dir):
                 os.makedirs(render_save_dir, exist_ok=True)


### PR DESCRIPTION
Added saving of cleared image and text blocks to auto mode
Now after finishing auto mode you can switch to manual, select an image, correct block boundaries or translation, press Undo Image (cleaned image will appear), and then through the top menu finish cleaning the image if it is not completely clean and insert the text again

![image](https://github.com/user-attachments/assets/99d5e4de-be47-4a0e-aebd-82f7c76cf0e3)

0) after the Automatic mode has been finalized, switch to Manual
1) select an image
2) return the cleaned image
3) select a block
4) correct the translation
5) paint over the places where the old text still needs to be cleaned
6) clean better
7) insert a new translation
8) save the image