### PR TITLE
Add support for local models (OpenAI compatible)

### DIFF
--- a/app/ui/settings/settings_page.py
+++ b/app/ui/settings/settings_page.py
@@ -61,7 +61,9 @@ class SettingsPage(QtWidgets.QWidget):
     def get_llm_settings(self):
         return {
             'extra_context': self.ui.llm_widgets['extra_context'].toPlainText(),
-            'image_input_enabled': self.ui.llm_widgets['image_input'].isChecked()
+            'image_input_enabled': self.ui.llm_widgets['image_input'].isChecked(),
+            'local_oai_url_input': self.ui.llm_widgets['local_oai_url_input'].text(),
+            'local_oai_model_input': self.ui.llm_widgets['local_oai_model_input'].text()
         }
 
     def get_export_settings(self):
@@ -268,6 +270,8 @@ class SettingsPage(QtWidgets.QWidget):
         settings.beginGroup('llm')
         self.ui.llm_widgets['extra_context'].setPlainText(settings.value('extra_context', ''))
         self.ui.llm_widgets['image_input'].setChecked(settings.value('image_input_enabled', True, type=bool))
+        self.ui.llm_widgets['local_oai_url_input'].setText(settings.value('local_oai_url_input', ''))
+        self.ui.llm_widgets['local_oai_model_input'].setText(settings.value('local_oai_model_input', ''))
         settings.endGroup()
 
         # Load export settings

--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -38,7 +38,7 @@ class SettingsPageUI(QtWidgets.QWidget):
                                     self.tr("Claude-3-Opus"), self.tr("Claude-3.5-Sonnet"), 
                                     self.tr("Claude-3-Haiku"), self.tr("Gemini-1.5-Flash"), 
                                     self.tr("Gemini-1.5-Pro"), self.tr("Yandex"), self.tr("Google Translate"),
-                                    self.tr("Microsoft Translator")]
+                                    self.tr("Microsoft Translator"), self.tr("Local OpenAI Server")]
         
         self.languages = ['English', '한국어', 'Français', '日本語', 
          '简体中文', '繁體中文', 'русский', 'Deutsch', 
@@ -78,6 +78,7 @@ class SettingsPageUI(QtWidgets.QWidget):
             self.tr("Yandex"): "Yandex",
             self.tr("Google Translate"): "Google Translate",
             self.tr("Microsoft Translator"): "Microsoft Translator",
+            self.tr("Local OpenAI Server"): "Local OpenAI Server",
 
             # OCR mappings
             self.tr("Default"): "Default",
@@ -435,9 +436,39 @@ class SettingsPageUI(QtWidgets.QWidget):
         image_checkbox.setChecked(True)
         self.llm_widgets['image_input'] = image_checkbox
 
+        # Local OpenAI
+        local_oai_label = MLabel(self.tr("Local OpenAI Server")).strong()
+
+        local_oai_url_input = MLineEdit()
+        local_oai_url_input.setFixedWidth(400)
+        local_oai_url_input.setPlaceholderText("http://localhost:1337/v1/")
+        local_oai_url_prefix = MLabel(self.tr("Base API URL")).border()
+
+        self.set_label_width(local_oai_url_prefix)
+        local_oai_url_prefix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        local_oai_url_input.set_prefix_widget(local_oai_url_prefix)
+
+        self.llm_widgets["local_oai_url_input"] = local_oai_url_input
+
+        local_oai_model_input = MLineEdit()
+        local_oai_model_input.setFixedWidth(400)
+        local_oai_model_input.setPlaceholderText("llama3.1-8b-instruct")
+        local_oai_model_prefix = MLabel(self.tr("Model ID")).border()
+
+        self.set_label_width(local_oai_model_prefix)
+        local_oai_model_prefix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        local_oai_model_input.set_prefix_widget(local_oai_model_prefix)
+
+        self.llm_widgets["local_oai_model_input"] = local_oai_model_input
+
+        
         llms_layout.addWidget(prompt_label)
         llms_layout.addWidget(self.llm_widgets['extra_context'])
         llms_layout.addWidget(image_checkbox)
+        llms_layout.addSpacing(20)  # Add 20 pixels of vertical spacing
+        llms_layout.addWidget(local_oai_label)
+        llms_layout.addWidget(local_oai_url_input)
+        llms_layout.addWidget(local_oai_model_input)
         llms_layout.addStretch(1)
 
         return llms_layout

--- a/modules/ocr/ocr.py
+++ b/modules/ocr/ocr.py
@@ -74,7 +74,7 @@ class OCRProcessor:
         elif self.gpt_ocr:
             credentials = self.settings.get_credentials(self.settings.ui.tr("Open AI GPT"))
             api_key = credentials['api_key']
-            gpt_client = get_llm_client('GPT', api_key)
+            gpt_client = get_llm_client('GPT', api_key, None)
             return self._ocr_gpt(img, blk_list, gpt_client)
 
         else:

--- a/modules/utils/translator_utils.py
+++ b/modules/utils/translator_utils.py
@@ -15,7 +15,7 @@ def encode_image_array(img_array: np.ndarray):
     _, img_bytes = cv2.imencode('.png', img_array)
     return base64.b64encode(img_bytes).decode('utf-8')
 
-def get_llm_client(translator: str, api_key: str):
+def get_llm_client(translator: str, api_key: str, base_url: str):
     if 'GPT' in translator:
         client  = OpenAI(api_key = api_key)
     elif 'Claude' in translator:
@@ -23,6 +23,11 @@ def get_llm_client(translator: str, api_key: str):
     elif 'Gemini' in translator:
         client = genai
         client.configure(api_key = api_key)
+    elif 'Local OpenAI' in translator:
+        client  = OpenAI(
+            api_key = "none", # Must be set, but not checked
+            base_url = base_url
+        )
     else:
         client = None
 


### PR DESCRIPTION
Using any of the current LLMs for translation is expensive, since you pay per-token for API calls. This PR adds an option to allow for a "Local OpenAI server" to be used instead.

This should allow for using locally hosted LLMs using tools such as [vLLM](https://docs.vllm.ai/en/latest/) or [Jan](https://jan.ai/docs). I have had success translating pages using Llama-3.1-8B-Instruct through Jan. **Importantly**, I have not tried vLLM, as I am running an M1 Mac, but it _should_ work. Anyone else able to verify this would be much appreciated.

Addresses issue #150 

This PR should be functional, but is marked as draft as the README still needs to be updated.