### PR TITLE
Add Custom LLM using OpenAI API

### DIFF
--- a/app/ui/settings/settings_page.py
+++ b/app/ui/settings/settings_page.py
@@ -87,6 +87,12 @@ class SettingsPage(QtWidgets.QWidget):
                     'save_key': save_keys,
                     'endpoint': self.ui.credential_widgets["Microsoft Azure_endpoint"].text()
                 }
+            elif service == "Custom":
+                return {
+                    'api_key': self.ui.credential_widgets[f"{service}_api_key"].text(),
+                    'api_url': self.ui.credential_widgets[f"{service}_api_url"].text(),
+                    'save_key': save_keys
+                }
             else:
                 return {
                     'api_key': self.ui.credential_widgets[f"{service}_api_key"].text(),
@@ -195,6 +201,9 @@ class SettingsPage(QtWidgets.QWidget):
                     settings.setValue(f"{translated_service}_api_key_translator", cred['api_key_translator'])
                     settings.setValue(f"{translated_service}_region_translator", cred['region_translator'])
                     settings.setValue(f"{translated_service}_endpoint", cred['endpoint'])
+                elif translated_service == "Custom":
+                    settings.setValue(f"{translated_service}_api_key", cred['api_key'])
+                    settings.setValue(f"{translated_service}_api_url", cred['api_url'])
                 else:
                     settings.setValue(f"{translated_service}_api_key", cred['api_key'])
         else:
@@ -293,6 +302,9 @@ class SettingsPage(QtWidgets.QWidget):
                     self.ui.credential_widgets["Microsoft Azure_api_key_translator"].setText(settings.value(f"{translated_service}_api_key_translator", ''))
                     self.ui.credential_widgets["Microsoft Azure_region"].setText(settings.value(f"{translated_service}_region_translator", ''))
                     self.ui.credential_widgets["Microsoft Azure_endpoint"].setText(settings.value(f"{translated_service}_endpoint", ''))
+                elif translated_service == "Custom":
+                    self.ui.credential_widgets[f"{service}_api_key"].setText(settings.value(f"{translated_service}_api_key", ''))
+                    self.ui.credential_widgets[f"{service}_api_url"].setText(settings.value(f"{translated_service}_api_url", ''))
                 else:
                     self.ui.credential_widgets[f"{service}_api_key"].setText(settings.value(f"{translated_service}_api_key", ''))
         settings.endGroup()

--- a/app/ui/settings/settings_page.py
+++ b/app/ui/settings/settings_page.py
@@ -91,6 +91,7 @@ class SettingsPage(QtWidgets.QWidget):
                 return {
                     'api_key': self.ui.credential_widgets[f"{service}_api_key"].text(),
                     'api_url': self.ui.credential_widgets[f"{service}_api_url"].text(),
+                    'model': self.ui.credential_widgets[f"{service}_model"].text(),
                     'save_key': save_keys
                 }
             else:
@@ -204,6 +205,7 @@ class SettingsPage(QtWidgets.QWidget):
                 elif translated_service == "Custom":
                     settings.setValue(f"{translated_service}_api_key", cred['api_key'])
                     settings.setValue(f"{translated_service}_api_url", cred['api_url'])
+                    settings.setValue(f"{translated_service}_model", cred['model'])
                 else:
                     settings.setValue(f"{translated_service}_api_key", cred['api_key'])
         else:
@@ -305,6 +307,7 @@ class SettingsPage(QtWidgets.QWidget):
                 elif translated_service == "Custom":
                     self.ui.credential_widgets[f"{service}_api_key"].setText(settings.value(f"{translated_service}_api_key", ''))
                     self.ui.credential_widgets[f"{service}_api_url"].setText(settings.value(f"{translated_service}_api_url", ''))
+                    self.ui.credential_widgets[f"{service}_model"].setText(settings.value(f"{translated_service}_model", ''))
                 else:
                     self.ui.credential_widgets[f"{service}_api_key"].setText(settings.value(f"{translated_service}_api_key", ''))
         settings.endGroup()

--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -424,6 +424,17 @@ class SettingsPageUI(QtWidgets.QWidget):
                 service_layout.addWidget(endpoint_input)
                 
                 self.credential_widgets[f"{service}_api_url"] = endpoint_input
+
+                # Model Name
+                model_input = MLineEdit()
+                model_input.setFixedWidth(400)
+                model_prefix = MLabel(self.tr("Model")).border()
+                self.set_label_width(model_prefix)
+                model_prefix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                model_input.set_prefix_widget(model_prefix)
+                service_layout.addWidget(model_input)
+                
+                self.credential_widgets[f"{service}_model"] = model_input
             else:
                 # API Key for other services
                 api_key_input = MLineEdit()

--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -35,14 +35,14 @@ class SettingsPageUI(QtWidgets.QWidget):
         self.themes = [self.tr('Dark'), self.tr('Light')]
         self.alignment = [self.tr("Left"), self.tr("Center"), self.tr("Right")]
 
-        self.credential_services = [self.tr("Deepseek"), self.tr("Open AI GPT"), self.tr("Microsoft Azure"), self.tr("Google Cloud"), 
+        self.credential_services = [self.tr("Custom"), self.tr("Deepseek"), self.tr("Open AI GPT"), self.tr("Microsoft Azure"), self.tr("Google Cloud"), 
                                     self.tr("Google Gemini"), self.tr("DeepL"), self.tr("Anthropic Claude"), self.tr("Yandex")]
         
         self.supported_translators = [self.tr("GPT-4o"), self.tr("GPT-4o mini"), self.tr("DeepL"), 
                                     self.tr("Claude-3-Opus"), self.tr("Claude-3.5-Sonnet"), 
                                     self.tr("Claude-3-Haiku"), self.tr("Gemini-1.5-Flash"), 
                                     self.tr("Gemini-1.5-Pro"), self.tr("Yandex"), self.tr("Google Translate"),
-                                    self.tr("Microsoft Translator"), self.tr("Deepseek-v3")]
+                                    self.tr("Microsoft Translator"), self.tr("Deepseek-v3"), self.tr("Custom"),]
         
         self.languages = ['English', '한국어', 'Français', '日本語', 
          '简体中文', '繁體中文', 'русский', 'Deutsch', 
@@ -71,6 +71,7 @@ class SettingsPageUI(QtWidgets.QWidget):
             self.tr("Light"): "Light",
 
             # Translator mappings
+            self.tr("Custom"): "Custom",
             self.tr("Deepseek-v3"): "Deepseek-v3",
             self.tr("GPT-4o"): "GPT-4o",
             self.tr("GPT-4o mini"): "GPT-4o mini",
@@ -103,6 +104,7 @@ class SettingsPageUI(QtWidgets.QWidget):
             self.tr("Right"): "Right",
 
             # Credential services mappings
+            self.tr("Custom"): "Custom",
             self.tr("Deepseek"): "Deepseek",
             self.tr("Open AI GPT"): "Open AI GPT",
             self.tr("Microsoft Azure"): "Microsoft Azure",
@@ -399,6 +401,29 @@ class SettingsPageUI(QtWidgets.QWidget):
                 service_layout.addWidget(region_input)
                 
                 self.credential_widgets["Microsoft Azure_region"] = region_input
+            elif service == "Custom":
+                # API Key
+                api_key_input = MLineEdit()
+                api_key_input.setEchoMode(QtWidgets.QLineEdit.Password)
+                api_key_input.setFixedWidth(400)
+                api_key_prefix = MLabel(self.tr("API Key")).border()
+                self.set_label_width(api_key_prefix)
+                api_key_prefix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                api_key_input.set_prefix_widget(api_key_prefix)
+                service_layout.addWidget(api_key_input)
+                
+                self.credential_widgets[f"{service}_api_key"] = api_key_input
+                
+                # Endpoint URL
+                endpoint_input = MLineEdit()
+                endpoint_input.setFixedWidth(400)
+                endpoint_prefix = MLabel(self.tr("Endpoint URL")).border()
+                self.set_label_width(endpoint_prefix)
+                endpoint_prefix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                endpoint_input.set_prefix_widget(endpoint_prefix)
+                service_layout.addWidget(endpoint_input)
+                
+                self.credential_widgets[f"{service}_api_url"] = endpoint_input
             else:
                 # API Key for other services
                 api_key_input = MLineEdit()

--- a/modules/translator.py
+++ b/modules/translator.py
@@ -21,13 +21,16 @@ class Translator:
         self.target_lang_en = self.get_english_lang(main_page, self.target_lang)
 
         self.api_key = self.get_api_key(self.translator_key)
-        self.client = get_llm_client(self.translator_key, self.api_key)
+        self.api_url = self.get_api_url(self.translator_key)
+        print(self.translator_key, self.api_key, self.api_url)
+        self.client = get_llm_client(self.translator_key, self.api_key, self.api_url)
 
         self.img_as_llm_input = self.settings.get_llm_settings()['image_input_enabled']
 
     def get_translator_key(self, localized_translator: str) -> str:
         # Map localized translator names to keys
         translator_map = {
+            self.settings.ui.tr("Custom"): "Custom",
             self.settings.ui.tr("Deepseek-v3"): "Deepseek-v3",
             self.settings.ui.tr("GPT-4o"): "GPT-4o",
             self.settings.ui.tr("GPT-4o mini"): "GPT-4o mini",
@@ -48,6 +51,7 @@ class Translator:
 
     def get_llm_model(self, translator_key: str):
         model_map = {
+            "Custom": "Custom",
             "Deepseek-v3": "deepseek-v3", 
             "GPT-4o": "gpt-4o",
             "GPT-4o mini": "gpt-4o-mini",
@@ -98,6 +102,8 @@ class Translator:
                     {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
                     {"role": "user", "content": [{"type": "text", "text": user_prompt}]}
                 ]
+
+        print(f'The model is set to: {model}')
 
         response = self.client.chat.completions.create(
             model=model,
@@ -204,7 +210,10 @@ class Translator:
             system_prompt = self.get_system_prompt(self.source_lang, self.target_lang)
             user_prompt = f"{extra_context}\nMake the translation sound as natural as possible.\nTranslate this:\n{entire_raw_text}"
 
-            if 'Deepseek' in self.translator_key:  # Add Deepseek v3 translation
+            if 'Custom' in self.translator_key:
+                model = 'llava:7b'
+                entire_translated_text = self.get_gpt_translation(user_prompt, model, system_prompt, image)
+            elif 'Deepseek' in self.translator_key:
                 entire_translated_text = self.get_deepseek_translation(user_prompt, system_prompt)
             elif 'GPT' in self.translator_key:
                 entire_translated_text = self.get_gpt_translation(user_prompt, model, system_prompt, image)
@@ -214,6 +223,7 @@ class Translator:
                 image = cv2_to_pil(image)
                 entire_translated_text = self.get_gemini_translation(user_prompt, model, system_prompt, image)
 
+            print(blk_list, entire_translated_text)
             set_texts_from_json(blk_list, entire_translated_text)
 
         return blk_list
@@ -223,7 +233,9 @@ class Translator:
 
         api_key = ""
 
-        if 'Deepseek' in translator_key:  # Add Deepseek v3 API key
+        if 'Custom' in translator_key:
+            api_key = credentials.get(self.settings.ui.tr('Custom'), {}).get('api_key', "")
+        elif 'Deepseek' in translator_key:
             api_key = credentials.get(self.settings.ui.tr('Deepseek'), {}).get('api_key', "")
         elif 'GPT' in translator_key:
             api_key = credentials.get(self.settings.ui.tr('Open AI GPT'), {}).get('api_key', "")
@@ -239,7 +251,18 @@ class Translator:
             }
             api_key = api_key_map.get(translator_key, "")
 
-        if not api_key and translator_key!= 'Google Translate':
+        if translator_key == 'Google Translate' or translator_key == 'Custom':
+            pass
+        elif not api_key:
             raise ValueError(f"API key not found for translator: {translator_key}")
 
         return api_key
+
+    def get_api_url(self, translator_key: str):
+        credentials = self.settings.get_credentials()
+        api_url = ""
+
+        if 'Custom' in translator_key:
+            api_url = credentials.get(self.settings.ui.tr('Custom'), {}).get('api_url', "")
+
+        return api_url

--- a/modules/translator.py
+++ b/modules/translator.py
@@ -22,7 +22,6 @@ class Translator:
 
         self.api_key = self.get_api_key(self.translator_key)
         self.api_url = self.get_api_url(self.translator_key)
-        print(self.translator_key, self.api_key, self.api_url)
         self.client = get_llm_client(self.translator_key, self.api_key, self.api_url)
 
         self.img_as_llm_input = self.settings.get_llm_settings()['image_input_enabled']
@@ -106,8 +105,6 @@ class Translator:
                     {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
                     {"role": "user", "content": [{"type": "text", "text": user_prompt}]}
                 ]
-
-        print(f'The model is set to: {model}')
 
         response = self.client.chat.completions.create(
             model=model,
@@ -226,7 +223,7 @@ class Translator:
                 image = cv2_to_pil(image)
                 entire_translated_text = self.get_gemini_translation(user_prompt, model, system_prompt, image)
 
-            print(blk_list, entire_translated_text)
+            # print(blk_list, entire_translated_text) 
             set_texts_from_json(blk_list, entire_translated_text)
 
         return blk_list

--- a/modules/translator.py
+++ b/modules/translator.py
@@ -49,22 +49,21 @@ class Translator:
         return main_page.lang_mapping.get(translated_lang, translated_lang)
 
     def get_llm_model(self, translator_key: str):
-        if translator_key == "Custom":
-            credentials = self.settings.get_credentials()
-            return credentials.get(self.settings.ui.tr('Custom'), {}).get('model', "")
-        else:
-            model_map = {
-                "Custom": "Custom",
-                "Deepseek-v3": "deepseek-v3", 
-                "GPT-4o": "gpt-4o",
-                "GPT-4o mini": "gpt-4o-mini",
-                "Claude-3-Opus": "claude-3-opus-20240229",
-                "Claude-3.5-Sonnet": "claude-3-5-sonnet-20241022",
-                "Claude-3-Haiku": "claude-3-haiku-20240307",
-                "Gemini-2.0-Flash": "gemini-2.0-flash-exp",
-                "Gemini-1.5-Pro": "gemini-1.5-pro-latest"
-            }
-            return model_map.get(translator_key)
+        credentials = self.settings.get_credentials()
+        custom_model = credentials.get(self.settings.ui.tr('Custom'), {}).get('model', '')
+
+        model_map = {
+            "Custom": custom_model,
+            "Deepseek-v3": "deepseek-v3", 
+            "GPT-4o": "gpt-4o",
+            "GPT-4o mini": "gpt-4o-mini",
+            "Claude-3-Opus": "claude-3-opus-20240229",
+            "Claude-3.5-Sonnet": "claude-3-5-sonnet-20241022",
+            "Claude-3-Haiku": "claude-3-haiku-20240307",
+            "Gemini-2.0-Flash": "gemini-2.0-flash-exp",
+            "Gemini-1.5-Pro": "gemini-1.5-pro-latest"
+        }
+        return model_map.get(translator_key)
         
     def get_system_prompt(self, source_lang: str, target_lang: str):
         return f"""You are an expert translator who translates {source_lang} to {target_lang}. You pay attention to style, formality, idioms, slang etc and try to convey it in the way a {target_lang} speaker would understand.
@@ -223,7 +222,6 @@ class Translator:
                 image = cv2_to_pil(image)
                 entire_translated_text = self.get_gemini_translation(user_prompt, model, system_prompt, image)
 
-            # print(blk_list, entire_translated_text) 
             set_texts_from_json(blk_list, entire_translated_text)
 
         return blk_list

--- a/modules/translator.py
+++ b/modules/translator.py
@@ -50,19 +50,23 @@ class Translator:
         return main_page.lang_mapping.get(translated_lang, translated_lang)
 
     def get_llm_model(self, translator_key: str):
-        model_map = {
-            "Custom": "Custom",
-            "Deepseek-v3": "deepseek-v3", 
-            "GPT-4o": "gpt-4o",
-            "GPT-4o mini": "gpt-4o-mini",
-            "Claude-3-Opus": "claude-3-opus-20240229",
-            "Claude-3.5-Sonnet": "claude-3-5-sonnet-20241022",
-            "Claude-3-Haiku": "claude-3-haiku-20240307",
-            "Gemini-1.5-Flash": "gemini-1.5-flash-latest",
-            "Gemini-1.5-Pro": "gemini-1.5-pro-latest"
-        }
-        return model_map.get(translator_key)
-    
+        if translator_key == "Custom":
+            credentials = self.settings.get_credentials()
+            return credentials.get(self.settings.ui.tr('Custom'), {}).get('model', "")
+        else:
+            model_map = {
+                "Custom": "Custom",
+                "Deepseek-v3": "deepseek-v3", 
+                "GPT-4o": "gpt-4o",
+                "GPT-4o mini": "gpt-4o-mini",
+                "Claude-3-Opus": "claude-3-opus-20240229",
+                "Claude-3.5-Sonnet": "claude-3-5-sonnet-20241022",
+                "Claude-3-Haiku": "claude-3-haiku-20240307",
+                "Gemini-1.5-Flash": "gemini-1.5-flash-latest",
+                "Gemini-1.5-Pro": "gemini-1.5-pro-latest"
+            }
+            return model_map.get(translator_key)
+        
     def get_system_prompt(self, source_lang: str, target_lang: str):
         return f"""You are an expert translator who translates {source_lang} to {target_lang}. You pay attention to style, formality, idioms, slang etc and try to convey it in the way a {target_lang} speaker would understand.
         BE MORE NATURAL. NEVER USE 당신, 그녀, 그 or its Japanese equivalents.
@@ -211,7 +215,6 @@ class Translator:
             user_prompt = f"{extra_context}\nMake the translation sound as natural as possible.\nTranslate this:\n{entire_raw_text}"
 
             if 'Custom' in self.translator_key:
-                model = 'llava:7b'
                 entire_translated_text = self.get_gpt_translation(user_prompt, model, system_prompt, image)
             elif 'Deepseek' in self.translator_key:
                 entire_translated_text = self.get_deepseek_translation(user_prompt, system_prompt)

--- a/modules/utils/translator_utils.py
+++ b/modules/utils/translator_utils.py
@@ -15,8 +15,10 @@ def encode_image_array(img_array: np.ndarray):
     _, img_bytes = cv2.imencode('.png', img_array)
     return base64.b64encode(img_bytes).decode('utf-8')
 
-def get_llm_client(translator: str, api_key: str):
-    if 'Deepseek' in translator:  # Add Deepseek client
+def get_llm_client(translator: str, api_key: str, api_url: str = ""):
+    if 'Custom' in translator:
+        client = OpenAI(api_key=api_key, base_url=api_url)
+    elif 'Deepseek' in translator:
         client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com/v1")
     elif 'GPT' in translator:
         client  = OpenAI(api_key = api_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opencv_python
-PySide6>=6.7.2
+PySide6==6.8.0
 dayu-path>=0.5.2
 msgpack>=1.1.0
 requests>=2.31.0
@@ -26,3 +26,6 @@ paddlepaddle>=2.6.1
 loguru>=0.7.2
 google-generativeai>=0.5.2
 anthropic>=0.25.6
+fugashi==1.4.0
+pyperclip==1.9.0
+unidic-lite==1.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opencv_python
-PySide6==6.8.0
+PySide6>=6.8.0
 dayu-path>=0.5.2
 msgpack>=1.1.0
 requests>=2.31.0
@@ -26,6 +26,6 @@ paddlepaddle>=2.6.1
 loguru>=0.7.2
 google-generativeai>=0.5.2
 anthropic>=0.25.6
-fugashi==1.4.0
-pyperclip==1.9.0
-unidic-lite==1.0.8
+fugashi>=1.4.0
+pyperclip>=1.9.0
+unidic-lite>=1.0.8


### PR DESCRIPTION
This PR adds the ability to specify a custom LLM. This can be used with an LLM that is on premise or an LLM running on a server farm.  The user must give the endpoint URL, the API key, and the model name. 

Ollama can use the OpenAI API, but its buried in their blog (https://ollama.com/blog/openai-compatibility). For example, here is my config using Deepseek R1 with Ollama (In this case, the API key is "ollama"):
![image](https://github.com/user-attachments/assets/9ee5cb57-e0a0-4517-b296-2e9b456f29c6)

I also had to change some of the dependencies in requirements.txt in order for me to build and run the program. Let me know if there are any changes you would like for me to make. This should allow you to close many of the issues pertaining to certain LLM requests or for running a local LLM.


