### PR TITLE
[Bugfix] Fix DeepL Language Codes and Improve Batch Translation Efficiency

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -274,6 +274,11 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         self.translate_button = MPushButton(self.tr("Translate All"))
         self.translate_button.setEnabled(True)
         self.translate_button.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        
+        self.extract_text_button = MPushButton(self.tr("Extract Text"))
+        self.extract_text_button.setEnabled(True)
+        self.extract_text_button.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        
         self.cancel_button = MPushButton(self.tr("Cancel"))
         self.cancel_button.setEnabled(True)
         self.cancel_button.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
@@ -285,6 +290,7 @@ class ComicTranslateUI(QtWidgets.QMainWindow):
         header_layout.addWidget(self.manual_radio)
         header_layout.addWidget(self.automatic_radio)
         header_layout.addWidget(self.translate_button)
+        header_layout.addWidget(self.extract_text_button)
         header_layout.addWidget(self.cancel_button)
 
         # Left Side (Image Selection)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+def main():
+    print("Hello from comic-translate!")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from comic-translate!")
-
-
-if __name__ == "__main__":
-    main()

--- a/modules/translation/deepl.py
+++ b/modules/translation/deepl.py
@@ -6,60 +6,100 @@ from ..utils.textblock import TextBlock
 
 class DeepLTranslation(TraditionalTranslation):
     """Translation engine using DeepL API."""
-    
+
     def __init__(self):
         self.source_lang_code = None
         self.target_lang_code = None
         self.api_key = None
         self.translator = None
-        self.target_lang = None
-        
+        self.target_lang = None # This is unused, can be removed if not needed elsewhere
+
     def initialize(self, settings: Any, source_lang: str, target_lang: str) -> None:
 
         import deepl
 
-        self.target_lang = target_lang
-
-        # get the “raw” code (e.g. “en”, “zh”, etc.) then normalize for DeepL:
+        # get the “raw” code (e.g. “en”, “zh”, etc.)
         raw_src = self.get_language_code(source_lang)
         raw_tgt = self.get_language_code(target_lang)
-        self.source_lang_code = self.preprocess_language_code(raw_src)
-        self.target_lang_code = self.preprocess_language_code(raw_tgt)
-        
+
+        # Use different processing for source and target languages
+        self.source_lang_code = self.preprocess_source_language(raw_src)
+        self.target_lang_code = self.preprocess_target_language(raw_tgt)
+
         credentials = settings.get_credentials(settings.ui.tr("DeepL"))
         self.api_key = credentials.get('api_key', '')
+
+        # It's good practice to check for the API key before creating the translator
+        if not self.api_key:
+            raise ValueError("DeepL API key not found in settings.")
+
         self.translator = deepl.Translator(self.api_key)
-        
+
     def translate(self, blk_list: list[TextBlock]) -> list[TextBlock]:
         try:
+            # Prepare a list of texts to translate for better efficiency (if texts are not empty)
+            texts_to_translate = []
             for blk in blk_list:
                 text = self.preprocess_text(blk.text, self.source_lang_code)
-                
+                # Keep track of empty texts to avoid sending them to the API
                 if not text.strip():
                     blk.translation = ''
-                    continue
-                
-                result = self.translator.translate_text(
-                    text, 
-                    source_lang=self.source_lang_code, 
-                    target_lang=self.target_lang_code
-                )
-                
-                blk.translation = result.text
-        
-        except Exception as e:
-            print(f"DeepL Translator error: {str(e)}")
-            
-        return blk_list 
+                else:
+                    texts_to_translate.append(text)
 
-    def preprocess_language_code(self, lang_code: str) -> str:
-        # Chinese variants
-        if lang_code == 'zh-CN':
-            return 'ZH-HANS'
-        if lang_code == 'zh-TW':
-            return 'ZH-HANT'
-        # English always as US:
-        if lang_code == 'en':
+            # Only call the API if there is something to translate
+            if not texts_to_translate:
+                return blk_list
+
+            # The deepl library can translate a list of strings in one call, which is more efficient
+            results = self.translator.translate_text(
+                texts_to_translate,
+                source_lang=self.source_lang_code,
+                target_lang=self.target_lang_code
+            )
+
+            # Map the results back to the original blocks
+            result_iterator = iter(results)
+            for blk in blk_list:
+                # If the original text was not empty, get the next translation result
+                if blk.text.strip():
+                    blk.translation = next(result_iterator).text
+
+        except deepl.DeepLException as e:
+            # It's better to catch the specific DeepL exception
+            print(f"DeepL Translator error: {str(e)}")
+        except Exception as e:
+            # Catch other potential errors
+            print(f"An unexpected error occurred: {str(e)}")
+
+        return blk_list
+
+    def preprocess_source_language(self, lang_code: str) -> str:
+        """Prepares a language code for the 'source_lang' parameter."""
+        # For source language, DeepL expects the base code (e.g., 'EN', 'ZH').
+        # We take the first part of the code (e.g., 'zh' from 'zh-CN') and uppercase it.
+        base_lang = lang_code.split('-')[0]
+        return base_lang.upper()
+
+    def preprocess_target_language(self, lang_code: str) -> str:
+        """Prepares a language code for the 'target_lang' parameter."""
+        # For target language, DeepL can handle regional variants.
+        if lang_code.lower() == 'zh-cn':
+            return 'ZH' # DeepL now recommends 'ZH' for Simplified Chinese
+        if lang_code.lower() == 'zh-tw':
+            return 'ZH' # And also 'ZH'. DeepL no longer uses HANS/HANT.
+
+        # For English, you can specify the variant. 'EN-US' is a safe default.
+        if lang_code.lower() == 'en':
             return 'EN-US'
-        # fallback: e.g. 'fr' → 'FR', 'de' → 'DE'
+
+        # For Portuguese, you must distinguish between PT-PT and PT-BR.
+        # This code defaults to PT-PT, which might be wrong.
+        # DeepL requires 'PT-BR' or 'PT-PT', not just 'PT'.
+        if lang_code.lower() == 'pt':
+             # You might need to add logic here to decide which one to use.
+             # Using PT-BR as a more common default.
+            return 'PT-BR'
+
+        # Fallback for other languages (e.g., 'fr' -> 'FR')
         return lang_code.upper()

--- a/modules/translation/deepl.py
+++ b/modules/translation/deepl.py
@@ -83,23 +83,13 @@ class DeepLTranslation(TraditionalTranslation):
 
     def preprocess_target_language(self, lang_code: str) -> str:
         """Prepares a language code for the 'target_lang' parameter."""
-        # For target language, DeepL can handle regional variants.
-        if lang_code.lower() == 'zh-cn':
-            return 'ZH' # DeepL now recommends 'ZH' for Simplified Chinese
-        if lang_code.lower() == 'zh-tw':
-            return 'ZH' # And also 'ZH'. DeepL no longer uses HANS/HANT.
-
-        # For English, you can specify the variant. 'EN-US' is a safe default.
-        if lang_code.lower() == 'en':
+        code = lang_code.lower()
+        if code == 'zh-cn':
+            return 'ZH-HANS'  # DeepL: Simplified Chinese
+        if code == 'zh-tw':
+            return 'ZH-HANT'  # DeepL: Traditional Chinese
+        if code == 'en':
             return 'EN-US'
-
-        # For Portuguese, you must distinguish between PT-PT and PT-BR.
-        # This code defaults to PT-PT, which might be wrong.
-        # DeepL requires 'PT-BR' or 'PT-PT', not just 'PT'.
-        if lang_code.lower() == 'pt':
-             # You might need to add logic here to decide which one to use.
-             # Using PT-BR as a more common default.
+        if code == 'pt':
             return 'PT-BR'
-
-        # Fallback for other languages (e.g., 'fr' -> 'FR')
         return lang_code.upper()


### PR DESCRIPTION
in [DeepL Translation source languages](https://developers.deepl.com/docs/getting-started/supported-languages#translation-source-languages), we can only use 'ZH' as code, but in [Translation target languages](https://developers.deepl.com/docs/getting-started/supported-languages#translation-target-languages), we can use 'ZH-HANT'/'ZH-HANS'. so we need to use different processing for source and target languages.