### PR TITLE
Resolve Qt threading error when loading project

### DIFF
--- a/app/controllers/projects.py
+++ b/app/controllers/projects.py
@@ -114,8 +114,8 @@ class ProjectController:
                           self.main.default_error_handler, self.update_ui_from_project, file_name)
 
     def load_project(self, file_name):
-        self.main.project_file = file_name
-        load_state_from_proj_file(self.main, file_name)
+      self.main.project_file = file_name
+      return load_state_from_proj_file(self.main, file_name)
 
     def save_main_page_settings(self):
         settings = QSettings("ComicLabs", "ComicTranslate")

--- a/app/projects/project_state.py
+++ b/app/projects/project_state.py
@@ -316,5 +316,5 @@ def load_state_from_proj_file(comic_translate, file_name):
 
     # restore LLM extra context
     saved_ctx = state.get('llm_extra_context', '')
-    comic_translate.settings_page.ui.extra_context.setPlainText(saved_ctx)
+    return saved_ctx
 


### PR DESCRIPTION
fix #294
this happened because load_state_from_proj_file() was directly calling setPlainText() on UI elements from worker threads, which Qt doesn't allow

to slove this 
- I modified load_state_from_proj_file() to return the context data instead of setting it in the UI
- Updated load_project() to return the loaded data
- UI updates now need to happen on the main thread after getting the returned data