### PR TITLE
Add quality picker for saving jpegs

### DIFF
--- a/app/controllers/image.py
+++ b/app/controllers/image.py
@@ -327,7 +327,17 @@ class ImageStateController:
         final_bgr = self.main.image_viewer.get_cv2_image(paint_all=True)
         final_rgb = cv2.cvtColor(final_bgr, cv2.COLOR_BGR2RGB)
         pil_img = Image.fromarray(final_rgb)
-        pil_img.save(file_path)
+        
+        settings = QtCore.QSettings("ComicLabs", "ComicTranslate")
+        settings.beginGroup('export')
+        jpeg_quality = settings.value('jpeg_quality', 95, type=int)
+        settings.endGroup()
+        
+        file_ext = os.path.splitext(file_path)[1].lower()
+        if file_ext in ['.jpg', '.jpeg']:
+            pil_img.save(file_path, quality=jpeg_quality, optimize=True)
+        else:
+            pil_img.save(file_path)
 
     def save_image_state(self, file: str):
         skip_status = self.main.image_states.get(file, {}).get('skip', False)

--- a/app/ui/canvas/save_renderer.py
+++ b/app/ui/canvas/save_renderer.py
@@ -2,6 +2,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 import cv2
 from PIL import Image
 import numpy as np
+import os
 from .text_item import TextBlockItem
 
 class ImageSaveRenderer:
@@ -112,7 +113,17 @@ class ImageSaveRenderer:
         final_bgr = self.render_to_image()
         final_rgb = cv2.cvtColor(final_bgr, cv2.COLOR_BGR2RGB)
         pil_img   = Image.fromarray(final_rgb)
-        pil_img.save(output_path)
+        
+        settings = QtCore.QSettings("ComicLabs", "ComicTranslate")
+        settings.beginGroup('export')
+        jpeg_quality = settings.value('jpeg_quality', 95, type=int)
+        settings.endGroup()
+        
+        file_ext = os.path.splitext(output_path)[1].lower()
+        if file_ext in ['.jpg', '.jpeg']:
+            pil_img.save(output_path, quality=jpeg_quality, optimize=True)
+        else:
+            pil_img.save(output_path)
 
     def apply_patches(self, patches: list[dict]):
         """Apply inpainting patches to the image."""

--- a/app/ui/settings/settings_page.py
+++ b/app/ui/settings/settings_page.py
@@ -26,6 +26,7 @@ TRANSLATOR_MIGRATIONS = {
 class SettingsPage(QtWidgets.QWidget):
     theme_changed = Signal(str)
     font_imported = Signal(str)
+    jpeg_quality_changed = Signal(int)
 
     def __init__(self, parent=None):
         super(SettingsPage, self).__init__(parent)
@@ -43,9 +44,20 @@ class SettingsPage(QtWidgets.QWidget):
         self.ui.theme_combo.currentTextChanged.connect(self.on_theme_changed)
         self.ui.lang_combo.currentTextChanged.connect(self.on_language_changed)
         self.ui.font_browser.sig_files_changed.connect(self.import_font)
+        self.ui.jpeg_quality_spinbox.valueChanged.connect(self.on_jpeg_quality_changed)
 
     def on_theme_changed(self, theme: str):
         self.theme_changed.emit(theme)
+    
+    def on_jpeg_quality_changed(self, value: int):
+        if not self._loading_settings:  # Avoid emitting during initial load
+            # Save the setting immediately
+            settings = QSettings("ComicLabs", "ComicTranslate")
+            settings.beginGroup('export')
+            settings.setValue('jpeg_quality', value)
+            settings.endGroup()
+            # Emit signal for any listeners
+            self.jpeg_quality_changed.emit(value)
 
     def get_language(self):
         return self.ui.lang_combo.currentText()
@@ -79,6 +91,7 @@ class SettingsPage(QtWidgets.QWidget):
             'export_raw_text': self.ui.raw_text_checkbox.isChecked(),
             'export_translated_text': self.ui.translated_text_checkbox.isChecked(),
             'export_inpainted_image': self.ui.inpainted_image_checkbox.isChecked(),
+            'jpeg_quality': self.ui.jpeg_quality_spinbox.value(),
             'save_as': {}
         }
         for file_type in self.ui.from_file_types:
@@ -300,6 +313,7 @@ class SettingsPage(QtWidgets.QWidget):
         self.ui.raw_text_checkbox.setChecked(settings.value('export_raw_text', False, type=bool))
         self.ui.translated_text_checkbox.setChecked(settings.value('export_translated_text', False, type=bool))
         self.ui.inpainted_image_checkbox.setChecked(settings.value('export_inpainted_image', False, type=bool))
+        self.ui.jpeg_quality_spinbox.setValue(settings.value('jpeg_quality', 95, type=int))
         settings.beginGroup('save_as')
         for file_type in ['.pdf', '.epub', '.cbr', '.cbz', '.cb7', '.cbt']:
             self.ui.export_widgets[f'{file_type}_save_as'].setCurrentText(settings.value(file_type, file_type[1:]))

--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -754,6 +754,27 @@ class SettingsPageUI(QtWidgets.QWidget):
         export_layout.addWidget(self.raw_text_checkbox)
         export_layout.addWidget(self.translated_text_checkbox)
         export_layout.addWidget(self.inpainted_image_checkbox)
+        
+        # Add JPEG Quality section
+        export_layout.addSpacing(20)
+        jpeg_quality_label = MLabel(self.tr("JPEG Quality")).h4()
+        export_layout.addWidget(jpeg_quality_label)
+        
+        jpeg_quality_layout = QtWidgets.QHBoxLayout()
+        self.jpeg_quality_spinbox = MSpinBox()
+        self.jpeg_quality_spinbox.setRange(1, 100)
+        self.jpeg_quality_spinbox.setValue(95)
+        self.jpeg_quality_spinbox.setSuffix("%")
+        self.jpeg_quality_spinbox.setFixedWidth(80)
+        
+        jpeg_quality_layout.addWidget(MLabel(self.tr("Quality:")))
+        jpeg_quality_layout.addWidget(self.jpeg_quality_spinbox)
+        jpeg_quality_layout.addStretch(1)
+        export_layout.addLayout(jpeg_quality_layout)
+        
+        export_layout.addSpacing(20)
+        file_conversion_label = MLabel(self.tr("File Format Conversion")).h4()
+        export_layout.addWidget(file_conversion_label)
 
         self.from_file_types = ['pdf', 'epub', 'cbr', 'cbz', 'cb7', 'cbt', 'zip', 'rar']
         available_file_types = ['pdf', 'cbz', 'cb7', 'zip']  # Exclude 'CBR' and add other types


### PR DESCRIPTION
When saving JPEGs, the default quality is quite low and introduces a lot of artifacts, so I added an option to allow the user to set the JPEG quality they want.