### PR TITLE
Fix broken resize behavior for text boxes

### DIFF
--- a/app/ui/canvas/text_item.py
+++ b/app/ui/canvas/text_item.py
@@ -133,12 +133,18 @@ class TextBlockItem(QGraphicsTextItem):
             self.font_family = font_family
             self.font_size = font_size
 
+        # Ensure minimum font size.
+        font_size = max(1, font_size)
+
         # Fallback to application default font family if none provided
         effective_family = font_family.strip() if isinstance(font_family, str) and font_family.strip() else QApplication.font().family()
         font = QFont(effective_family, font_size)
         self.update_text_format('font', font)
 
     def set_font_size(self, font_size):
+        # Ensure minimum font size.
+        font_size = max(1, font_size)
+        
         if not self.textCursor().hasSelection():
             self.font_size = font_size
         self.update_text_format('size', font_size)
@@ -549,10 +555,20 @@ class TextBlockItem(QGraphicsTextItem):
         
         # Update size and font
         self.setTextWidth(new_rect.width())
+
+        # Update the font size proportionally with minimum size constraint.
         if original_height > 0:
             height_ratio = new_rect.height() / original_height
             new_font_size = self.font_size * height_ratio
-            self.set_font_size(new_font_size)
+            
+            # Ensure minimum font size of 1pt.
+            min_font_size = 1
+            if new_font_size >= min_font_size:
+                self.font_size = new_font_size
+                self.set_font_size(new_font_size)
+            else:
+                # If font would become invalid, stop the resize.
+                return
 
         self.resize_start = scene_pos
 

--- a/app/ui/canvas/text_item.py
+++ b/app/ui/canvas/text_item.py
@@ -554,7 +554,7 @@ class TextBlockItem(QGraphicsTextItem):
             new_font_size = self.font_size * height_ratio
             self.set_font_size(new_font_size)
 
-        self._resize_start = scene_pos
+        self.resize_start = scene_pos
 
     def on_selection_changed(self):
         cursor = self.textCursor()


### PR DESCRIPTION
## Description
- Resolves #327.
- This problem was introduced in 19bd26c5f1916d03d93ee5ad15b505cb81e97cda with the change from `self._resize_start` to `self.resize_start`. That is the first half of the problem.
- The second half of the problem was the font size would become invalid if resized too small and you will get spammed with `QFont::setPointSize` errors. Added font size validation so it will always be at least `1pt`.