### PR TITLE
fixed patch highlighting error via BGR to RGB conversion

### DIFF
--- a/app/ui/canvas/save_renderer.py
+++ b/app/ui/canvas/save_renderer.py
@@ -212,6 +212,10 @@ class ImageSaveRenderer:
             # Extract data from the patch dict
             x, y, w, h = patch['bbox']
             patch_image = cv2.imread(patch['png_path']) if 'png_path' in patch else patch['cv2_img']
+
+            # Convert BGR patch to RGB for proper QImage conversion
+            if len(patch_image.shape) == 3:
+                patch_image = cv2.cvtColor(patch_image, cv2.COLOR_BGR2RGB)
             
             # Convert patch to QImage
             patch_qimage = self.cv2_to_qimage(patch_image)


### PR DESCRIPTION
Looks like the apply_patches function in save_renderer.py was missing a BGR to RGB conversion that caused export all images to output colored patch overlays onto output comics instead of being transparent. I spent a couple hours digging through the code to find this and fix it for myself, so maybe the main repo can make use of the fix, and others can avoid tearing their hair out assuming they missed a setting somewhere.