### PR TITLE
Fix: Remove top_p parameter from Claude API requests

### DIFF
--- a/modules/translation/llm/claude.py
+++ b/modules/translation/llm/claude.py
@@ -50,8 +50,7 @@ class ClaudeTranslation(BaseLLMTranslation):
             "model": self.model,
             "system": system_prompt,
             "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
-            "top_p": self.top_p,
+            "max_tokens": self.max_tokens
         }
         
         # Add messages with text and optionally image


### PR DESCRIPTION
## Description
Fixes Claude API 400 error when both `temperature` and `top_p` parameters are provided.

## Problem
The Claude API returns an error when both `temperature` and `top_p` are specified in the request:
```
Error 400: `temperature` and `top_p` cannot both be specified for this model. Please use only one.
```

## Solution
Removed the `top_p` parameter from the API request payload in `ClaudeTranslation._perform_translation()`.

## Testing
- Tested translation requests with Claude API
- Verified that temperature parameter alone works correctly
- No more 400 errors during API calls