### PR TITLE
Add Replicate API inpainting backend

### DIFF
--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -54,15 +54,15 @@ class SettingsPageUI(QtWidgets.QWidget):
         self.credential_widgets = {}
         self.export_widgets = {}
 
-        self.inpainters = ['LaMa', 'AOT']
+        self.inpainters = ['LaMa', 'AOT', 'Replicate']
         self.detectors = ['RT-DETR-v2']
         self.ocr_engines = [self.tr("Default"), self.tr('Microsoft OCR'), self.tr('Google Cloud Vision'), self.tr('Gemini-2.0-Flash'), self.tr('GPT-4.1-mini')]
         self.inpaint_strategy = [self.tr('Resize'), self.tr('Original'), self.tr('Crop')]
         self.themes = [self.tr('Dark'), self.tr('Light')]
         self.alignment = [self.tr("Left"), self.tr("Center"), self.tr("Right")]
 
-        self.credential_services = [self.tr("Custom"), self.tr("Deepseek"), self.tr("Open AI GPT"), self.tr("Microsoft Azure"), self.tr("Google Cloud"), 
-                                    self.tr("Google Gemini"), self.tr("DeepL"), self.tr("Anthropic Claude"), self.tr("Yandex")]
+        self.credential_services = [self.tr("Custom"), self.tr("Deepseek"), self.tr("Open AI GPT"), self.tr("Microsoft Azure"), self.tr("Google Cloud"),
+                                    self.tr("Google Gemini"), self.tr("DeepL"), self.tr("Anthropic Claude"), self.tr("Yandex"), self.tr("Replicate")]
         
         self.supported_translators = [self.tr("GPT-4.1"), self.tr("GPT-4.1-mini"), self.tr("DeepL"), 
                                     self.tr("Claude-4.5-Sonnet"), self.tr("Claude-4.5-Haiku"),
@@ -117,6 +117,7 @@ class SettingsPageUI(QtWidgets.QWidget):
             # Inpainter mappings
             "LaMa": "LaMa",
             "AOT": "AOT",
+            "Replicate": "Replicate",
 
             # Detector mappings
             "RT-DETR-v2": "RT-DETR-v2",
@@ -141,6 +142,7 @@ class SettingsPageUI(QtWidgets.QWidget):
             self.tr("DeepL"): "DeepL",
             self.tr("Anthropic Claude"): "Anthropic Claude",
             self.tr("Yandex"): "Yandex",
+            self.tr("Replicate"): "Replicate",
         }
 
         # Create reverse mappings for loading

--- a/modules/inpainting/replicate_inpaint.py
+++ b/modules/inpainting/replicate_inpaint.py
@@ -1,0 +1,111 @@
+import logging
+import base64
+import io
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+from .base import InpaintModel
+from .schema import Config
+
+logger = logging.getLogger(__name__)
+
+# Import guard for replicate
+try:
+    import replicate
+    REPLICATE_AVAILABLE = True
+except ImportError:
+    replicate = None
+    REPLICATE_AVAILABLE = False
+
+
+class ReplicateInpaint(InpaintModel):
+    name = "replicate"
+    pad_mod = 8
+
+    def __init__(self, device, **kwargs):
+        self.api_key: Optional[str] = kwargs.get('api_key')
+        super().__init__(device, **kwargs)
+
+    def init_model(self, device, **kwargs):
+        """Initialize the Replicate API client."""
+        # Set backend to 'onnx' to avoid torch import in base class __call__
+        self.backend = kwargs.get("backend", "onnx")
+
+        if not REPLICATE_AVAILABLE:
+            raise ImportError("replicate package is not installed. Install it with: pip install replicate")
+
+        if not self.api_key:
+            raise ValueError("Replicate API key is required. Configure it in Settings > Credentials.")
+
+        # Set the API token for the replicate client
+        import os
+        os.environ["REPLICATE_API_TOKEN"] = self.api_key
+
+    @staticmethod
+    def is_downloaded() -> bool:
+        """API-based model is always 'available' if replicate is installed."""
+        return REPLICATE_AVAILABLE
+
+    def forward(self, image, mask, config: Config):
+        """
+        Run inpainting via Replicate API.
+
+        Args:
+            image: [H, W, C] RGB numpy array
+            mask: [H, W] numpy array, 255 = mask area
+
+        Returns:
+            RGB numpy array
+        """
+        # Convert image to base64 PNG
+        img_pil = Image.fromarray(image.astype(np.uint8))
+        img_buffer = io.BytesIO()
+        img_pil.save(img_buffer, format='PNG')
+        img_base64 = base64.b64encode(img_buffer.getvalue()).decode('utf-8')
+        img_data_uri = f"data:image/png;base64,{img_base64}"
+
+        # Convert mask to base64 PNG (ensure it's proper format)
+        # Squeeze mask to 2D if it has shape (H, W, 1)
+        if mask.ndim == 3:
+            mask = mask.squeeze(axis=-1)
+        mask_pil = Image.fromarray(mask.astype(np.uint8), mode='L')
+        mask_buffer = io.BytesIO()
+        mask_pil.save(mask_buffer, format='PNG')
+        mask_base64 = base64.b64encode(mask_buffer.getvalue()).decode('utf-8')
+        mask_data_uri = f"data:image/png;base64,{mask_base64}"
+
+        logger.info("Calling Replicate LaMa inpainting API...")
+
+        try:
+            # Call Replicate API - using twn39/lama model with full version ID
+            output = replicate.run(
+                "twn39/lama:2b91ca2340801c2a5be745612356fac36a17f698354a07f48a62d564d3b3a7a0",
+                input={
+                    "image": img_data_uri,
+                    "mask": mask_data_uri,
+                }
+            )
+
+            # Output is a URL to the result image
+            # Download and convert to numpy array
+            import requests
+            response = requests.get(output, timeout=60)
+            response.raise_for_status()
+
+            result_pil = Image.open(io.BytesIO(response.content))
+            result_array = np.array(result_pil)
+
+            # Ensure RGB format (result should already be RGB)
+            if result_array.ndim == 2:
+                result_array = np.stack([result_array] * 3, axis=-1)
+            elif result_array.shape[-1] == 4:
+                result_array = result_array[:, :, :3]
+
+            logger.info("Replicate inpainting completed successfully")
+            return result_array
+
+        except Exception as e:
+            logger.error(f"Replicate API error: {e}")
+            raise RuntimeError(f"Replicate inpainting failed: {e}")

--- a/modules/utils/pipeline_utils.py
+++ b/modules/utils/pipeline_utils.py
@@ -11,6 +11,7 @@ from modules.detection.utils.content import get_inpaint_bboxes
 from modules.inpainting.lama import LaMa
 from modules.inpainting.mi_gan import MIGAN
 from modules.inpainting.aot import AOT
+from modules.inpainting.replicate_inpaint import ReplicateInpaint
 from modules.inpainting.schema import Config
 from app.ui.messages import Messages
 
@@ -53,6 +54,7 @@ inpaint_map = {
     "LaMa": LaMa,
     "MI-GAN": MIGAN,
     "AOT": AOT,
+    "Replicate": ReplicateInpaint,
 }
 
 def get_config(settings_page):

--- a/pipeline/inpainting.py
+++ b/pipeline/inpainting.py
@@ -37,7 +37,16 @@ class InpaintingHandler:
             device = resolve_device(settings_page.is_gpu_enabled(), backend)
             inpainter_key = settings_page.get_tool_selection('inpainter')
             InpainterClass = inpaint_map[inpainter_key]
-            self.inpainter_cache = InpainterClass(device, backend=backend)
+
+            # Pass API key for Replicate cloud inpainter
+            if inpainter_key == "Replicate":
+                credentials = settings_page.get_credentials("Replicate")
+                api_key = credentials.get('api_key', '')
+                if not api_key:
+                    raise ValueError("Replicate API key is required. Configure it in Settings > Credentials.")
+                self.inpainter_cache = InpainterClass(device, backend=backend, api_key=api_key)
+            else:
+                self.inpainter_cache = InpainterClass(device, backend=backend)
             self.cached_inpainter_key = inpainter_key
 
         config = get_config(settings_page)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ onnxruntime>=1.22.1
 shapely>=2.1.1
 pyclipper>=1.3.0.post6
 six>=1.16.0
+replicate>=0.25.0


### PR DESCRIPTION
  Closes #394 

  Add Replicate API option for Clean Image step.

  ## Changes
  - Add `ReplicateInpaint` class in `modules/inpainting/replicate_inpaint.py`
    - Uses LaMa model via Replicate API
    - Handles image/mask encoding to base64
  - Add "Replicate" to inpainter dropdown
  - Add API key field in Settings > Credentials
  - Add `replicate` to requirements.txt (optional, import guarded)

  ## Usage
  1. Get API key from https://replicate.com
  2. Settings → Credentials → Replicate
  3. Settings → Tools → Inpainter → Replicate

  Runs on NVIDIA L40S, ~$0.001/sec.

  ## Tested
  Manual test with sample manga - inpainting works correctly.