### PR TITLE
 Fix: Unable to select Yandex Translate API in Russian localization

### DIFF
--- a/resources/translations/ct_ru.ts
+++ b/resources/translations/ct_ru.ts
@@ -51,7 +51,7 @@
         <location filename="../../modules/utils/pipeline_config.py" line="102"/>
         <location filename="../../modules/utils/pipeline_config.py" line="103"/>
         <source>Yandex</source>
-        <translation>Яндекс</translation>
+        <translation>Yandex</translation>
     </message>
     <message>
         <location filename="../../modules/utils/pipeline_config.py" line="115"/>
@@ -1357,7 +1357,7 @@ Please sign in via Settings &gt; Account to use credits, or configure Custom API
         <location filename="../../app/ui/settings/settings_ui.py" line="128"/>
         <location filename="../../app/ui/settings/settings_ui.py" line="162"/>
         <source>Yandex</source>
-        <translation>Яндекс</translation>
+        <translation>Yandex</translation>
     </message>
     <message>
         <location filename="../../app/ui/settings/settings_ui.py" line="81"/>


### PR DESCRIPTION
There is a critical bug when the application language is set to Russian. The "Yandex" translator option in the settings menu is localized as "Яндекс". In [app/ui/settings_page.py](https://github.com/ogkalu2/comic-translate/blob/dc9a606339ca30b1bd6df68773ddc3ab93ac213e/app/ui/settings/settings_page.py) at line [116](https://github.com/ogkalu2/comic-translate/blob/dc9a606339ca30b1bd6df68773ddc3ab93ac213e/app/ui/settings/settings_page.py#L116), the application performs a check: service == "Yandex". Since "Яндекс" != "Yandex", this condition fails, making it impossible to select and use the Yandex Translate API when the Russian interface is active.

Changes:
The translation string for the Yandex service has been changed to match the expected internal identifier "Yandex".

Impact:
Fixes the broken service selection in the settings UI for Russian-speaking users. Restores functionality for Yandex Translate API.