### PR TITLE
Fix MIME type from 'image/jpg' to 'image/jpeg'

### DIFF
--- a/modules/ocr/gemini_ocr.py
+++ b/modules/ocr/gemini_ocr.py
@@ -111,7 +111,7 @@ class GeminiOCR(OCREngine):
                 "parts": [
                     {
                         "inline_data": {
-                            "mime_type": "image/jpg",
+                            "mime_type": "image/jpeg",
                             "data": base64_image
                         }
                     },


### PR DESCRIPTION
image/jpg isn’t a valid MIME type per spec.
The server will reject unsupported types like this:

> API error: 400 {
>   "error": {
>     "code": 400,
>     "message": "Unsupported MIME type: image/jpg",
>     "status": "INVALID_ARGUMENT"
>   }
> }
