### PR TITLE
feat: add presets workflow, model upgrades, and output resize controls

### DIFF
--- a/app/controllers/image.py
+++ b/app/controllers/image.py
@@ -1001,12 +1001,35 @@ class ImageStateController:
                 PatchCommandBase.create_patch_item(prop, self.main.image_viewer)
 
     def save_current_image(self, file_path: str):
+        import logging
+        from modules.utils.resize_output import apply_output_resize, apply_width_limit_resize
+
+        _logger = logging.getLogger(__name__)
+
         if self.main.webtoon_mode:
             # In webtoon mode, get the visible area image which combines all visible pages
             final_rgb, _ = self.main.image_viewer.get_visible_area_image(paint_all=True)
         else:
             # In regular mode, get the current single image
             final_rgb = self.main.image_viewer.get_image_array(paint_all=True)
+
+        if final_rgb is not None:
+            _logger.info(
+                "save_current_image: rendered image size before resize: %s",
+                final_rgb.shape,
+            )
+
+        # Apply HD Strategy Resize post-processing (if configured)
+        final_rgb = apply_output_resize(final_rgb, self.main.settings_page)
+
+        # Apply Output Width Limit (if configured in Export settings)
+        final_rgb = apply_width_limit_resize(final_rgb, self.main.settings_page)
+
+        if final_rgb is not None:
+            _logger.info(
+                "save_current_image: final image size after all resize: %s -> %s",
+                final_rgb.shape, file_path,
+            )
 
         imk.write_image(file_path, final_rgb)
 

--- a/app/controllers/presets.py
+++ b/app/controllers/presets.py
@@ -1,0 +1,207 @@
+"""Controller for Tool Presets feature.
+
+Handles the bridge between the PresetPanel UI and the main application
+toolbar widgets. Responsible for:
+- Applying a preset (setting all toolbar widgets + updating selected text items)
+- Capturing current toolbar state into a new preset
+- Importing fonts and creating presets from imported files
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QFontDatabase
+
+from app.ui.preset_model import ToolPreset
+from app.ui.commands.textformat import TextFormatCommand
+from modules.utils.paths import get_user_data_dir
+
+if TYPE_CHECKING:
+    from controller import ComicTranslate
+
+logger = logging.getLogger(__name__)
+
+
+class PresetController:
+    """Manages applying / capturing tool presets."""
+
+    def __init__(self, main: ComicTranslate):
+        self.main = main
+
+    # ── Apply preset ─────────────────────────────────────────────────
+
+    def apply_preset(self, preset: ToolPreset) -> None:
+        """Apply all properties from *preset* to the toolbar widgets.
+
+        If text items are currently selected, the formatting is also
+        applied to them via the undo/redo command system.
+        """
+        logger.info("Applying preset: %s", preset.name)
+
+        # Block signals from all text widgets to prevent cascading updates
+        widgets = self.main.text_ctrl.widgets_to_block
+        self.main.text_ctrl.block_text_item_widgets(widgets)
+
+        try:
+            # Font family
+            resolved = self.main.ensure_custom_font_loaded(preset.font_family)
+            self.main.set_font(resolved)
+
+            # Font size
+            self.main.font_size_dropdown.setCurrentText(str(preset.font_size))
+
+            # Line spacing
+            self.main.line_spacing_dropdown.setCurrentText(str(preset.line_spacing))
+
+            # Font color
+            self.main.block_font_color_button.setStyleSheet(
+                f"background-color: {preset.color}; border: none; border-radius: 5px;"
+            )
+            self.main.block_font_color_button.setProperty("selected_color", preset.color)
+
+            # Bold / Italic / Underline
+            self.main.bold_button.setChecked(preset.bold)
+            self.main.italic_button.setChecked(preset.italic)
+            self.main.underline_button.setChecked(preset.underline)
+
+            # Alignment
+            alignment_index = max(0, min(2, preset.alignment))
+            self.main.alignment_tool_group.set_dayu_checked(alignment_index)
+
+            # Outline
+            self.main.outline_checkbox.setChecked(preset.outline)
+            self.main.outline_font_color_button.setStyleSheet(
+                f"background-color: {preset.outline_color}; border: none; border-radius: 5px;"
+            )
+            self.main.outline_font_color_button.setProperty(
+                "selected_color", preset.outline_color
+            )
+            self.main.outline_width_dropdown.setCurrentText(str(preset.outline_width))
+
+        finally:
+            self.main.text_ctrl.unblock_text_item_widgets(widgets)
+
+        # Apply to selected text items if any
+        self._apply_to_selected_items(preset)
+
+    def _apply_to_selected_items(self, preset: ToolPreset) -> None:
+        """Apply the preset to all currently selected text items."""
+        items = self.main.text_ctrl._selected_text_items()
+        if not items:
+            return
+
+        alignment_map = {
+            0: Qt.AlignmentFlag.AlignLeft,
+            1: Qt.AlignmentFlag.AlignCenter,
+            2: Qt.AlignmentFlag.AlignRight,
+        }
+        alignment = alignment_map.get(preset.alignment, Qt.AlignmentFlag.AlignCenter)
+
+        outline_color = QColor(preset.outline_color) if preset.outline else None
+        outline_width = preset.outline_width if preset.outline else 0.0
+
+        commands = []
+        for item in items:
+            old_item = copy.copy(item)
+
+            # Apply all properties
+            resolved = self.main.ensure_custom_font_loaded(preset.font_family)
+            item.set_font(resolved, preset.font_size)
+            item.set_color(QColor(preset.color))
+            item.set_bold(preset.bold)
+            item.set_italic(preset.italic)
+            item.set_underline(preset.underline)
+            item.set_alignment(alignment)
+            item.set_line_spacing(preset.line_spacing)
+            if preset.outline:
+                item.set_outline(QColor(preset.outline_color), preset.outline_width)
+            else:
+                item.set_outline(None, None)
+
+            commands.append(
+                TextFormatCommand(self.main.image_viewer, old_item, item)
+            )
+
+        stack = self.main.undo_group.activeStack()
+        if stack is None:
+            return
+
+        if len(commands) > 1:
+            stack.beginMacro("apply_preset")
+        try:
+            for command in commands:
+                stack.push(command)
+        finally:
+            if len(commands) > 1:
+                stack.endMacro()
+
+        # Sync toolbar with the (now applied) item
+        if self.main.curr_tblock_item in items:
+            self.main.text_ctrl.set_values_for_blk_item(self.main.curr_tblock_item)
+
+    # ── Capture current state ────────────────────────────────────────
+
+    def capture_current_as_preset(self, name: str) -> ToolPreset:
+        """Read all current toolbar values and build a ToolPreset."""
+        alignment_id = self.main.alignment_tool_group.get_dayu_checked()
+
+        preset = ToolPreset(
+            name=name,
+            font_family=self.main.font_dropdown.currentText(),
+            font_size=int(self.main.font_size_dropdown.currentText() or "12"),
+            bold=self.main.bold_button.isChecked(),
+            italic=self.main.italic_button.isChecked(),
+            underline=self.main.underline_button.isChecked(),
+            line_spacing=float(self.main.line_spacing_dropdown.currentText() or "1.0"),
+            color=self.main.block_font_color_button.property("selected_color") or "#000000",
+            outline=self.main.outline_checkbox.isChecked(),
+            outline_color=self.main.outline_font_color_button.property("selected_color") or "#ffffff",
+            outline_width=float(self.main.outline_width_dropdown.currentText() or "1.0"),
+            alignment=alignment_id,
+        )
+        logger.info("Captured preset: %s", preset.name)
+        return preset
+
+    # ── Handle preset panel signals ──────────────────────────────────
+
+    def on_capture_requested(self, name: str) -> None:
+        """Connected to PresetPanel.capture_requested signal."""
+        panel = self.main.preset_panel
+        if not name:
+            # Update mode
+            preset = self.capture_current_as_preset("")
+            panel.update_preset_entry(preset)
+        else:
+            # New preset  mode
+            preset = self.capture_current_as_preset(name)
+            panel.add_preset_entry(preset)
+
+    def on_fonts_imported(self, payload: list) -> None:
+        """Connected to PresetPanel.fonts_imported signal.
+
+        *payload* is ``[(category_name, file_paths, results)]`` where
+        *results* is from ``PresetManager.import_fonts_to_category``.
+        """
+        if not payload:
+            return
+
+        for cat_name, file_paths, results in payload:
+            resolved_entries: list[tuple[str, str]] = []
+
+            for basename, display_name in results:
+                # Load the font into QFontDatabase
+                fonts_dir = os.path.join(get_user_data_dir(), "fonts")
+                full_path = os.path.join(fonts_dir, basename)
+                family = self.main._load_custom_font_file(full_path)
+                if family:
+                    resolved_entries.append((display_name, family))
+                else:
+                    resolved_entries.append((display_name, display_name))
+
+            panel = self.main.preset_panel
+            panel.finalize_font_import(cat_name, resolved_entries)

--- a/app/controllers/projects.py
+++ b/app/controllers/projects.py
@@ -920,7 +920,7 @@ class ProjectController:
                         renderer.add_state_to_image(viewer_state)
 
                     sv_pth = os.path.join(group_dir, self._build_export_page_name(page_number, file_path))
-                    renderer.save_image(sv_pth)
+                    renderer.save_image(sv_pth, settings_page=self.main.settings_page)
 
                 os.makedirs(os.path.dirname(group["output_path"]) or ".", exist_ok=True)
                 make(group_dir, group["output_path"])

--- a/app/ui/canvas/save_renderer.py
+++ b/app/ui/canvas/save_renderer.py
@@ -229,8 +229,12 @@ class ImageSaveRenderer:
 
         return arr
 
-    def save_image(self, output_path: str):
+    def save_image(self, output_path: str, settings_page=None):
         final_rgb = self.render_to_image()
+        if settings_page is not None:
+            from modules.utils.resize_output import apply_output_resize, apply_width_limit_resize
+            final_rgb = apply_output_resize(final_rgb, settings_page)
+            final_rgb = apply_width_limit_resize(final_rgb, settings_page)
         imk.write_image(output_path, final_rgb)
 
     def apply_patches(self, patches: list[dict]):

--- a/app/ui/main_window/builders/nav.py
+++ b/app/ui/main_window/builders/nav.py
@@ -204,11 +204,15 @@ class NavRailMixin:
         return nav_rail_layout
 
     def _set_search_sidebar_visible(self, visible: bool):
-        if not hasattr(self, "search_panel") or not hasattr(self, "page_list"):
+        if not hasattr(self, "search_panel"):
             return
+        tab_widget = getattr(self, "left_tab_widget", None)
         try:
             self.search_panel.setVisible(bool(visible))
-            self.page_list.setVisible(not bool(visible))
+            if tab_widget is not None:
+                tab_widget.setVisible(not bool(visible))
+            elif hasattr(self, "page_list"):
+                self.page_list.setVisible(not bool(visible))
         except Exception:
             return
 

--- a/app/ui/main_window/builders/workspace.py
+++ b/app/ui/main_window/builders/workspace.py
@@ -17,6 +17,7 @@ from app.ui.dayu_widgets.slider import MSlider
 from app.ui.dayu_widgets.text_edit import MTextEdit
 from app.ui.dayu_widgets.tool_button import MToolButton
 from app.ui.search_replace_panel import SearchReplacePanel
+from app.ui.preset_panel import PresetPanel
 from app.ui.main_window.constants import supported_source_languages, supported_target_languages
 
 
@@ -98,11 +99,37 @@ class WorkspaceMixin:
         left_layout = QtWidgets.QVBoxLayout()
         left_layout.addWidget(MDivider())
 
+        # Tab widget for Pages / Tool Presets
+        self.left_tab_widget = QtWidgets.QTabWidget()
+        self.left_tab_widget.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        self.left_tab_widget.setStyleSheet(
+            "QTabWidget::pane { border: none; }"
+            "QTabBar::tab { padding: 5px 12px; font-size: 11px; }"
+            "QTabBar::tab:selected { font-weight: bold; }"
+        )
+
+        # Tab 0: Pages
         self.image_card_layout = QtWidgets.QVBoxLayout()
         self.image_card_layout.addStretch(1)
-
         self.page_list.setLayout(self.image_card_layout)
-        left_layout.addWidget(self.page_list)
+
+        page_tab = QtWidgets.QWidget()
+        page_tab_layout = QtWidgets.QVBoxLayout(page_tab)
+        page_tab_layout.setContentsMargins(0, 0, 0, 0)
+        page_tab_layout.addWidget(self.page_list)
+
+        # Tab 1: Tool Presets
+        self.preset_panel = PresetPanel(self)
+
+        preset_tab = QtWidgets.QWidget()
+        preset_tab_layout = QtWidgets.QVBoxLayout(preset_tab)
+        preset_tab_layout.setContentsMargins(0, 0, 0, 0)
+        preset_tab_layout.addWidget(self.preset_panel)
+
+        self.left_tab_widget.addTab(page_tab, self.tr("Pages"))
+        self.left_tab_widget.addTab(preset_tab, self.tr("Tool Presets"))
+
+        left_layout.addWidget(self.left_tab_widget)
         left_layout.addWidget(self.search_panel)
         left_widget = QtWidgets.QWidget()
         left_widget.setLayout(left_layout)

--- a/app/ui/preset_model.py
+++ b/app/ui/preset_model.py
@@ -1,0 +1,266 @@
+"""Tool Presets data model and persistence layer.
+
+Each preset captures a full text-rendering configuration so typesetters
+can swap between distinct font/style combos with a single click.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from dataclasses import asdict, dataclass, field
+from typing import List, Optional
+
+from modules.utils.paths import get_user_data_dir
+
+logger = logging.getLogger(__name__)
+
+# ── Paths ────────────────────────────────────────────────────────────
+_PRESETS_DIR_NAME = "presets"
+_FONTS_DIR_NAME = "fonts"
+
+
+def _presets_dir() -> str:
+    d = os.path.join(get_user_data_dir(), _PRESETS_DIR_NAME)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _fonts_dir() -> str:
+    d = os.path.join(get_user_data_dir(), _FONTS_DIR_NAME)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+# ── Data classes ─────────────────────────────────────────────────────
+
+@dataclass
+class ToolPreset:
+    """A single tool preset – full text formatting snapshot."""
+
+    name: str = ""
+    font_family: str = ""
+    font_size: int = 12
+    bold: bool = False
+    italic: bool = False
+    underline: bool = False
+    line_spacing: float = 1.0
+    color: str = "#000000"
+    outline: bool = True
+    outline_color: str = "#ffffff"
+    outline_width: float = 1.0
+    alignment: int = 1  # 0=left, 1=center, 2=right
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ToolPreset:
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in d.items() if k in known}
+        return cls(**filtered)
+
+
+@dataclass
+class PresetCategory:
+    """A named group of presets (e.g. 'Manga-Fantasy')."""
+
+    name: str = "Default"
+    presets: List[ToolPreset] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "presets": [p.to_dict() for p in self.presets],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> PresetCategory:
+        name = d.get("name", "Default")
+        presets = [ToolPreset.from_dict(p) for p in d.get("presets", [])]
+        return cls(name=name, presets=presets)
+
+
+# ── Manager ──────────────────────────────────────────────────────────
+
+class PresetManager:
+    """Manages persistence of preset categories as JSON files.
+
+    Directory layout::
+
+        <user_data_dir>/presets/
+            Default.json
+            Manga-Fantasy.json
+            Manhwa-Manhua.json
+    """
+
+    _FONT_EXTENSIONS = frozenset({".ttf", ".ttc", ".otf", ".woff", ".woff2"})
+
+    def __init__(self) -> None:
+        self._categories: dict[str, PresetCategory] = {}
+        self.reload()
+
+    # ── public API ───────────────────────────────────────────────────
+
+    @property
+    def category_names(self) -> list[str]:
+        return sorted(self._categories.keys())
+
+    def get_category(self, name: str) -> Optional[PresetCategory]:
+        return self._categories.get(name)
+
+    def reload(self) -> None:
+        """Re-scan the presets directory and load all categories."""
+        self._categories.clear()
+        presets_dir = _presets_dir()
+        for fname in os.listdir(presets_dir):
+            if not fname.lower().endswith(".json"):
+                continue
+            fpath = os.path.join(presets_dir, fname)
+            try:
+                with open(fpath, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                cat = PresetCategory.from_dict(data)
+                self._categories[cat.name] = cat
+            except Exception:
+                logger.warning("Failed to load preset file: %s", fpath, exc_info=True)
+
+        # Ensure at least a "Default" category exists
+        if not self._categories:
+            self.create_category("Default")
+
+    def save_category(self, name: str) -> None:
+        cat = self._categories.get(name)
+        if cat is None:
+            return
+        fpath = os.path.join(_presets_dir(), f"{cat.name}.json")
+        try:
+            with open(fpath, "w", encoding="utf-8") as f:
+                json.dump(cat.to_dict(), f, indent=2, ensure_ascii=False)
+        except Exception:
+            logger.error("Failed to save category '%s'", name, exc_info=True)
+
+    def create_category(self, name: str) -> PresetCategory:
+        name = name.strip()
+        if not name:
+            name = "Default"
+        if name in self._categories:
+            return self._categories[name]
+        cat = PresetCategory(name=name)
+        self._categories[name] = cat
+        self.save_category(name)
+        return cat
+
+    def delete_category(self, name: str) -> bool:
+        if name not in self._categories:
+            return False
+        fpath = os.path.join(_presets_dir(), f"{name}.json")
+        try:
+            if os.path.isfile(fpath):
+                os.remove(fpath)
+        except OSError:
+            logger.warning("Could not remove preset file: %s", fpath, exc_info=True)
+        del self._categories[name]
+        # Always keep at least one category
+        if not self._categories:
+            self.create_category("Default")
+        return True
+
+    def rename_category(self, old_name: str, new_name: str) -> bool:
+        new_name = new_name.strip()
+        if not new_name or old_name not in self._categories or new_name in self._categories:
+            return False
+        cat = self._categories.pop(old_name)
+        # Remove old file
+        old_path = os.path.join(_presets_dir(), f"{old_name}.json")
+        try:
+            if os.path.isfile(old_path):
+                os.remove(old_path)
+        except OSError:
+            pass
+        cat.name = new_name
+        self._categories[new_name] = cat
+        self.save_category(new_name)
+        return True
+
+    # ── Preset CRUD ──────────────────────────────────────────────────
+
+    def add_preset(self, category_name: str, preset: ToolPreset) -> None:
+        cat = self._categories.get(category_name)
+        if cat is None:
+            cat = self.create_category(category_name)
+        cat.presets.append(preset)
+        self.save_category(category_name)
+
+    def remove_preset(self, category_name: str, index: int) -> bool:
+        cat = self._categories.get(category_name)
+        if cat is None or index < 0 or index >= len(cat.presets):
+            return False
+        cat.presets.pop(index)
+        self.save_category(category_name)
+        return True
+
+    def update_preset(self, category_name: str, index: int, preset: ToolPreset) -> bool:
+        cat = self._categories.get(category_name)
+        if cat is None or index < 0 or index >= len(cat.presets):
+            return False
+        cat.presets[index] = preset
+        self.save_category(category_name)
+        return True
+
+    def rename_preset(self, category_name: str, index: int, new_name: str) -> bool:
+        cat = self._categories.get(category_name)
+        if cat is None or index < 0 or index >= len(cat.presets):
+            return False
+        cat.presets[index].name = new_name.strip()
+        self.save_category(category_name)
+        return True
+
+    def move_preset(self, category_name: str, from_index: int, to_index: int) -> bool:
+        cat = self._categories.get(category_name)
+        if cat is None:
+            return False
+        presets = cat.presets
+        if from_index < 0 or from_index >= len(presets) or to_index < 0 or to_index >= len(presets):
+            return False
+        p = presets.pop(from_index)
+        presets.insert(to_index, p)
+        self.save_category(category_name)
+        return True
+
+    # ── Font import helpers ──────────────────────────────────────────
+
+    def import_fonts_to_category(
+        self, category_name: str, font_paths: list[str]
+    ) -> list[tuple[str, str]]:
+        """Copy font files into the user fonts dir and create preset entries.
+
+        Returns list of (font_file_basename, family_name) for each
+        successfully imported font. The caller is responsible for loading
+        the font into QFontDatabase before calling this, since that is a
+        GUI concern.  The *family_name* reported here is just the file
+        basename without extension (a best-guess display name); the
+        actual family name should be resolved by the caller after loading.
+        """
+        results: list[tuple[str, str]] = []
+        fonts_dir = _fonts_dir()
+
+        for src in font_paths:
+            ext = os.path.splitext(src)[1].lower()
+            if ext not in self._FONT_EXTENSIONS:
+                continue
+            basename = os.path.basename(src)
+            dst = os.path.join(fonts_dir, basename)
+            if os.path.normcase(src) != os.path.normcase(dst):
+                try:
+                    shutil.copy2(src, dst)
+                except OSError:
+                    logger.warning("Could not copy font %s → %s", src, dst, exc_info=True)
+                    continue
+
+            display_name = os.path.splitext(basename)[0]
+            results.append((basename, display_name))
+
+        return results

--- a/app/ui/preset_panel.py
+++ b/app/ui/preset_panel.py
@@ -1,0 +1,406 @@
+"""Tool Presets panel widget for the typesetter workflow.
+
+Displays a list of presets organized by category inside a left-panel
+tab. The typesetter clicks a preset to instantly apply a full set of
+text formatting properties (font, size, color, outline, alignment, etc.).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtCore import Signal
+
+from app.ui.dayu_widgets.combo_box import MComboBox
+from app.ui.dayu_widgets.divider import MDivider
+from app.ui.dayu_widgets.label import MLabel
+from app.ui.dayu_widgets.push_button import MPushButton
+from app.ui.dayu_widgets.tool_button import MToolButton
+
+from .preset_model import PresetManager, ToolPreset
+
+if TYPE_CHECKING:
+    pass
+
+
+class PresetListItem(QtWidgets.QWidget):
+    """Custom list-item widget showing a font icon and preset name."""
+
+    clicked = Signal()
+
+    def __init__(self, preset: ToolPreset, parent=None):
+        super().__init__(parent)
+        self.preset = preset
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(6, 3, 6, 3)
+        layout.setSpacing(6)
+
+        # Font preview icon — show "A" in the preset's font
+        self.icon_label = QtWidgets.QLabel("A")
+        self.icon_label.setFixedSize(22, 22)
+        self.icon_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self._apply_icon_style()
+
+        # Preset name
+        self.name_label = QtWidgets.QLabel(preset.name)
+        self.name_label.setStyleSheet("font-size: 12px;")
+
+        layout.addWidget(self.icon_label)
+        layout.addWidget(self.name_label)
+        layout.addStretch()
+
+    def _apply_icon_style(self):
+        p = self.preset
+        weight = "bold" if p.bold else "normal"
+        style = "italic" if p.italic else "normal"
+        self.icon_label.setStyleSheet(
+            f"font-family: '{p.font_family}';"
+            f"font-size: 14px;"
+            f"font-weight: {weight};"
+            f"font-style: {style};"
+            f"color: {p.color};"
+            f"background-color: rgba(255,255,255,15);"
+            f"border-radius: 3px;"
+        )
+
+
+class PresetPanel(QtWidgets.QWidget):
+    """Panel for managing and applying tool presets.
+
+    Lives inside a tab in the left panel, alongside the Pages tab.
+    """
+
+    # Emitted when user clicks a preset; payload is the ToolPreset to apply
+    preset_applied = Signal(object)
+    # Emitted when user wants to save current toolbar state
+    capture_requested = Signal(str)  # preset name
+    # Emitted when fonts are imported (list of absolute paths)
+    fonts_imported = Signal(list)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._manager = PresetManager()
+
+        self._build_ui()
+        self._populate_categories()
+        self._connect_signals()
+
+    # ── UI construction ──────────────────────────────────────────────
+
+    def _build_ui(self):
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.setContentsMargins(4, 4, 4, 4)
+        main_layout.setSpacing(4)
+
+        # ── Category selector row ────────────────────────────────────
+        cat_layout = QtWidgets.QHBoxLayout()
+        cat_layout.setSpacing(2)
+
+        self._category_combo = MComboBox().small()
+        self._category_combo.setToolTip(self.tr("Select preset category"))
+        self._category_combo.setMinimumWidth(60)
+
+        self._add_cat_btn = MToolButton()
+        self._add_cat_btn.set_dayu_svg("add_line.svg")
+        self._add_cat_btn.setToolTip(self.tr("Create new category"))
+
+        self._del_cat_btn = MToolButton()
+        self._del_cat_btn.set_dayu_svg("minus_line.svg")
+        self._del_cat_btn.setToolTip(self.tr("Delete current category"))
+
+        self._rename_cat_btn = MToolButton()
+        self._rename_cat_btn.set_dayu_svg("settings.svg")
+        self._rename_cat_btn.setToolTip(self.tr("Rename current category"))
+
+        cat_layout.addWidget(self._category_combo, 1)
+        cat_layout.addWidget(self._add_cat_btn)
+        cat_layout.addWidget(self._rename_cat_btn)
+        cat_layout.addWidget(self._del_cat_btn)
+
+        main_layout.addLayout(cat_layout)
+
+        # ── Action buttons row ───────────────────────────────────────
+        action_layout = QtWidgets.QHBoxLayout()
+        action_layout.setSpacing(2)
+
+        self._add_preset_btn = MToolButton()
+        self._add_preset_btn.set_dayu_svg("add_line.svg")
+        self._add_preset_btn.setToolTip(self.tr("Save current settings as a new preset"))
+
+        self._import_fonts_btn = MToolButton()
+        self._import_fonts_btn.set_dayu_svg("folder-open.svg")
+        self._import_fonts_btn.setToolTip(self.tr("Import font files into this category"))
+
+        self._delete_preset_btn = MToolButton()
+        self._delete_preset_btn.set_dayu_svg("trash_line.svg")
+        self._delete_preset_btn.setToolTip(self.tr("Delete selected preset"))
+
+        action_layout.addStretch()
+        action_layout.addWidget(self._add_preset_btn)
+        action_layout.addWidget(self._import_fonts_btn)
+        action_layout.addWidget(self._delete_preset_btn)
+
+        main_layout.addLayout(action_layout)
+
+        # ── Preset list (fills remaining space) ──────────────────────
+        self._preset_list = QtWidgets.QListWidget()
+        self._preset_list.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        self._preset_list.setContextMenuPolicy(
+            QtCore.Qt.ContextMenuPolicy.CustomContextMenu
+        )
+        self._preset_list.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        self._preset_list.setStyleSheet(
+            "QListWidget { border: 1px solid rgba(255,255,255,20); border-radius: 4px; }"
+            "QListWidget::item { padding: 2px 0; }"
+            "QListWidget::item:selected { background-color: rgba(64,158,255,60); }"
+            "QListWidget::item:hover { background-color: rgba(255,255,255,10); }"
+        )
+
+        main_layout.addWidget(self._preset_list, 1)  # stretch=1 fills space
+
+    def _connect_signals(self):
+        self._add_preset_btn.clicked.connect(self._on_add_preset)
+        self._import_fonts_btn.clicked.connect(self._on_import_fonts)
+        self._delete_preset_btn.clicked.connect(self._on_delete_preset)
+        self._add_cat_btn.clicked.connect(self._on_add_category)
+        self._del_cat_btn.clicked.connect(self._on_delete_category)
+        self._rename_cat_btn.clicked.connect(self._on_rename_category)
+        self._category_combo.currentTextChanged.connect(self._on_category_changed)
+        self._preset_list.itemClicked.connect(self._on_preset_clicked)
+        self._preset_list.customContextMenuRequested.connect(self._show_context_menu)
+
+    # ── Populate ─────────────────────────────────────────────────────
+
+    def _populate_categories(self):
+        self._category_combo.blockSignals(True)
+        self._category_combo.clear()
+        names = self._manager.category_names
+        self._category_combo.addItems(names)
+        self._category_combo.blockSignals(False)
+        if names:
+            self._category_combo.setCurrentText(names[0])
+            self._refresh_preset_list()
+
+    def _refresh_preset_list(self):
+        self._preset_list.clear()
+        cat_name = self._category_combo.currentText()
+        cat = self._manager.get_category(cat_name)
+        if cat is None:
+            return
+
+        for preset in cat.presets:
+            item = QtWidgets.QListWidgetItem()
+            widget = PresetListItem(preset)
+            item.setSizeHint(widget.sizeHint())
+            self._preset_list.addItem(item)
+            self._preset_list.setItemWidget(item, widget)
+
+    # ── Category actions ─────────────────────────────────────────────
+
+    def _on_category_changed(self, name: str):
+        self._refresh_preset_list()
+
+    def _on_add_category(self):
+        name, ok = QtWidgets.QInputDialog.getText(
+            self, self.tr("New Category"), self.tr("Category name:")
+        )
+        if ok and name.strip():
+            self._manager.create_category(name.strip())
+            self._populate_categories()
+            self._category_combo.setCurrentText(name.strip())
+
+    def _on_delete_category(self):
+        cat_name = self._category_combo.currentText()
+        if not cat_name:
+            return
+        reply = QtWidgets.QMessageBox.question(
+            self,
+            self.tr("Delete Category"),
+            self.tr('Delete category "%s" and all its presets?') % cat_name,
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.No,
+        )
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
+            self._manager.delete_category(cat_name)
+            self._populate_categories()
+
+    def _on_rename_category(self):
+        old_name = self._category_combo.currentText()
+        if not old_name:
+            return
+        new_name, ok = QtWidgets.QInputDialog.getText(
+            self,
+            self.tr("Rename Category"),
+            self.tr("New name:"),
+            text=old_name,
+        )
+        if ok and new_name.strip() and new_name.strip() != old_name:
+            if self._manager.rename_category(old_name, new_name.strip()):
+                self._populate_categories()
+                self._category_combo.setCurrentText(new_name.strip())
+
+    # ── Preset actions ───────────────────────────────────────────────
+
+    def _on_preset_clicked(self, item: QtWidgets.QListWidgetItem):
+        row = self._preset_list.row(item)
+        cat_name = self._category_combo.currentText()
+        cat = self._manager.get_category(cat_name)
+        if cat and 0 <= row < len(cat.presets):
+            self.preset_applied.emit(cat.presets[row])
+
+    def _on_add_preset(self):
+        name, ok = QtWidgets.QInputDialog.getText(
+            self, self.tr("New Preset"), self.tr("Preset name:")
+        )
+        if ok and name.strip():
+            self.capture_requested.emit(name.strip())
+
+    def add_preset_entry(self, preset: ToolPreset):
+        """Called by the controller after capturing current settings."""
+        cat_name = self._category_combo.currentText()
+        if not cat_name:
+            cat_name = "Default"
+        self._manager.add_preset(cat_name, preset)
+        self._refresh_preset_list()
+
+    def _on_delete_preset(self):
+        row = self._preset_list.currentRow()
+        if row < 0:
+            return
+        cat_name = self._category_combo.currentText()
+        cat = self._manager.get_category(cat_name)
+        if cat is None or row >= len(cat.presets):
+            return
+
+        preset_name = cat.presets[row].name
+        reply = QtWidgets.QMessageBox.question(
+            self,
+            self.tr("Delete Preset"),
+            self.tr('Delete preset "%s"?') % preset_name,
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.No,
+        )
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
+            self._manager.remove_preset(cat_name, row)
+            self._refresh_preset_list()
+
+    def _on_import_fonts(self):
+        file_paths, _ = QtWidgets.QFileDialog.getOpenFileNames(
+            self,
+            self.tr("Import Font Files"),
+            "",
+            self.tr("Font files (*.ttf *.ttc *.otf *.woff *.woff2)"),
+        )
+        if not file_paths:
+            return
+
+        cat_name = self._category_combo.currentText()
+        if not cat_name:
+            cat_name = "Default"
+
+        # Copy files to user fonts dir and get base names
+        results = self._manager.import_fonts_to_category(cat_name, file_paths)
+
+        # Emit signal so the controller can load fonts into QFontDatabase
+        # and create proper presets with resolved family names
+        self.fonts_imported.emit(
+            [(cat_name, file_paths, results)]
+        )
+
+    def finalize_font_import(
+        self, category_name: str, font_entries: list[tuple[str, str]]
+    ):
+        """Called after controller resolves font families.
+
+        *font_entries* is a list of ``(display_name, resolved_family)``.
+        Creates a preset for each imported font.
+        """
+        for display_name, family_name in font_entries:
+            preset = ToolPreset(
+                name=f"{display_name} ({family_name})" if family_name != display_name else display_name,
+                font_family=family_name,
+            )
+            self._manager.add_preset(category_name, preset)
+
+        if self._category_combo.currentText() == category_name:
+            self._refresh_preset_list()
+
+    # ── Context menu ─────────────────────────────────────────────────
+
+    def _show_context_menu(self, pos: QtCore.QPoint):
+        item = self._preset_list.itemAt(pos)
+        if item is None:
+            return
+        row = self._preset_list.row(item)
+        cat_name = self._category_combo.currentText()
+        cat = self._manager.get_category(cat_name)
+        if cat is None or row >= len(cat.presets):
+            return
+
+        menu = QtWidgets.QMenu(self)
+
+        rename_action = menu.addAction(self.tr("Rename"))
+        update_action = menu.addAction(self.tr("Update with current settings"))
+        menu.addSeparator()
+        delete_action = menu.addAction(self.tr("Delete"))
+
+        action = menu.exec(self._preset_list.mapToGlobal(pos))
+        if action is None:
+            return
+
+        if action == rename_action:
+            self._rename_preset(row, cat_name)
+        elif action == update_action:
+            self._update_preset(row)
+        elif action == delete_action:
+            self._manager.remove_preset(cat_name, row)
+            self._refresh_preset_list()
+
+    def _rename_preset(self, row: int, cat_name: str):
+        cat = self._manager.get_category(cat_name)
+        if cat is None or row >= len(cat.presets):
+            return
+        old_name = cat.presets[row].name
+        new_name, ok = QtWidgets.QInputDialog.getText(
+            self,
+            self.tr("Rename Preset"),
+            self.tr("New name:"),
+            text=old_name,
+        )
+        if ok and new_name.strip():
+            self._manager.rename_preset(cat_name, row, new_name.strip())
+            self._refresh_preset_list()
+
+    def _update_preset(self, row: int):
+        """Request the controller to overwrite this preset with current settings."""
+        cat_name = self._category_combo.currentText()
+        cat = self._manager.get_category(cat_name)
+        if cat is None or row >= len(cat.presets):
+            return
+        # Store the update target so the controller can find it
+        self._pending_update_index = row
+        self._pending_update_category = cat_name
+        self.capture_requested.emit("")  # empty name = update mode
+
+    def update_preset_entry(self, preset: ToolPreset):
+        """Called by controller in update mode."""
+        cat_name = getattr(self, "_pending_update_category", None)
+        row = getattr(self, "_pending_update_index", -1)
+        if cat_name is None or row < 0:
+            return
+        preset.name = self._manager.get_category(cat_name).presets[row].name
+        self._manager.update_preset(cat_name, row, preset)
+        self._refresh_preset_list()
+        self._pending_update_category = None
+        self._pending_update_index = -1
+
+    # ── Public helpers ───────────────────────────────────────────────
+
+    @property
+    def manager(self) -> PresetManager:
+        return self._manager

--- a/app/ui/settings/export_page.py
+++ b/app/ui/settings/export_page.py
@@ -1,6 +1,8 @@
 from PySide6 import QtWidgets
 from ..dayu_widgets.label import MLabel
 from ..dayu_widgets.check_box import MCheckBox
+from ..dayu_widgets.spin_box import MSpinBox
+from ..dayu_widgets.divider import MDivider
 
 class ExportPage(QtWidgets.QWidget):
     def __init__(self, parent=None):
@@ -24,5 +26,42 @@ class ExportPage(QtWidgets.QWidget):
         layout.addWidget(self.raw_text_checkbox)
         layout.addWidget(self.translated_text_checkbox)
         layout.addWidget(self.inpainted_image_checkbox)
+
+        # ── Output Sizing ──────────────────────────────────────────
+        layout.addSpacing(10)
+        layout.addWidget(MDivider())
+
+        output_sizing_label = MLabel(self.tr("Output Sizing")).h4()
+        output_sizing_note = MLabel(
+            self.tr(
+                "Scale exported images so their width matches the specified value.\n"
+                "Height adjusts proportionally to maintain the aspect ratio."
+            )
+        ).secondary()
+        output_sizing_note.setWordWrap(True)
+
+        self.limit_width_checkbox = MCheckBox(self.tr("Limit Output Width"))
+
+        width_input_layout = QtWidgets.QHBoxLayout()
+        width_label = MLabel(self.tr("Width:"))
+        self.output_width_spinbox = MSpinBox().small()
+        self.output_width_spinbox.setFixedWidth(80)
+        self.output_width_spinbox.setMinimum(100)
+        self.output_width_spinbox.setMaximum(5000)
+        self.output_width_spinbox.setValue(960)
+        self.output_width_spinbox.setEnabled(False)
+        width_px_label = MLabel("px")
+        width_input_layout.addWidget(width_label)
+        width_input_layout.addWidget(self.output_width_spinbox)
+        width_input_layout.addWidget(width_px_label)
+        width_input_layout.addStretch()
+
+        # Enable/disable spinbox based on checkbox state
+        self.limit_width_checkbox.toggled.connect(self.output_width_spinbox.setEnabled)
+
+        layout.addWidget(output_sizing_label)
+        layout.addWidget(output_sizing_note)
+        layout.addWidget(self.limit_width_checkbox)
+        layout.addLayout(width_input_layout)
 
         layout.addStretch(1)

--- a/app/ui/settings/settings_page.py
+++ b/app/ui/settings/settings_page.py
@@ -149,6 +149,8 @@ class SettingsPage(QtWidgets.QWidget):
             'export_raw_text': self.ui.raw_text_checkbox.isChecked(),
             'export_translated_text': self.ui.translated_text_checkbox.isChecked(),
             'export_inpainted_image': self.ui.inpainted_image_checkbox.isChecked(),
+            'limit_output_width': self.ui.limit_width_checkbox.isChecked(),
+            'output_width_limit': int(self.ui.output_width_spinbox.value()),
             'project_autosave_enabled': autosave_enabled,
             'project_autosave_interval_min': int(self.ui.project_autosave_interval_spinbox.value()),
             'project_autosave_folder': autosave_folder,
@@ -177,12 +179,13 @@ class SettingsPage(QtWidgets.QWidget):
     def get_hd_strategy_settings(self):
         strategy = self.ui.inpaint_strategy_combo.currentText()
         settings = {
-            'strategy': strategy
+            'strategy': strategy,
+            # Always include resize_limit so downstream consumers
+            # (e.g. apply_output_resize) never fall back to 0.
+            'resize_limit': self.ui.resize_spinbox.value(),
         }
 
-        if strategy == self.ui.tr("Resize"):
-            settings['resize_limit'] = self.ui.resize_spinbox.value()
-        elif strategy == self.ui.tr("Crop"):
+        if strategy == self.ui.tr("Crop"):
             settings['crop_margin'] = self.ui.crop_margin_spinbox.value()
             settings['crop_trigger_size'] = self.ui.crop_trigger_spinbox.value()
 
@@ -392,6 +395,8 @@ class SettingsPage(QtWidgets.QWidget):
         self.ui.raw_text_checkbox.setChecked(settings.value('export_raw_text', False, type=bool))
         self.ui.translated_text_checkbox.setChecked(settings.value('export_translated_text', False, type=bool))
         self.ui.inpainted_image_checkbox.setChecked(settings.value('export_inpainted_image', False, type=bool))
+        self.ui.limit_width_checkbox.setChecked(settings.value('limit_output_width', False, type=bool))
+        self.ui.output_width_spinbox.setValue(settings.value('output_width_limit', 960, type=int))
         autosave_enabled = settings.value('project_autosave_enabled', False, type=bool)
         owner = self.parent()
         title_bar = getattr(owner, "title_bar", None)

--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 from PySide6 import QtWidgets
 from PySide6 import QtCore
 
@@ -53,12 +53,13 @@ class SettingsPageUI(QtWidgets.QWidget):
 
         self.credential_widgets = {}
 
-        self.inpainters = ['LaMa', 'AOT']
-        self.detectors = ['RT-DETR-v2']
+        self.inpainters = ['LaMa', 'LaMa Large', 'AOT', 'MI-GAN', 'Manga Inpainting']
+        self.detectors = ['RT-DETR-v2', 'YOLOv8']
         self.ocr_engines = [
             self.tr("Default"), 
             self.tr('Microsoft OCR'), 
             self.tr('Gemini-2.0-Flash'), 
+            self.tr('Manga OCR 2025'),
         ]
         self.inpaint_strategy = [self.tr('Resize'), self.tr('Original'), self.tr('Crop')]
         self.themes = [self.tr('Dark'), self.tr('Light')]
@@ -126,13 +127,18 @@ class SettingsPageUI(QtWidgets.QWidget):
             self.tr("Default"): "Default",
             self.tr("Microsoft OCR"): "Microsoft OCR",
             self.tr("Google Cloud Vision"): "Google Cloud Vision",
+            self.tr("Manga OCR 2025"): "Manga OCR 2025",
 
             # Inpainter mappings
             "LaMa": "LaMa",
+            "LaMa Large": "LaMa Large",
             "AOT": "AOT",
+            "MI-GAN": "MI-GAN",
+            "Manga Inpainting": "Manga Inpainting",
 
             # Detector mappings
             "RT-DETR-v2": "RT-DETR-v2",
+            "YOLOv8": "YOLOv8",
 
             # HD Strategy mappings
             self.tr("Resize"): "Resize",
@@ -230,6 +236,8 @@ class SettingsPageUI(QtWidgets.QWidget):
         self.raw_text_checkbox = self.export_page.raw_text_checkbox
         self.translated_text_checkbox = self.export_page.translated_text_checkbox
         self.inpainted_image_checkbox = self.export_page.inpainted_image_checkbox
+        self.limit_width_checkbox = self.export_page.limit_width_checkbox
+        self.output_width_spinbox = self.export_page.output_width_spinbox
         self.project_autosave_interval_spinbox = self.project_page.project_autosave_interval_spinbox
         self.project_autosave_folder_input = self.project_page.project_autosave_folder_input
 

--- a/controller.py
+++ b/controller.py
@@ -33,6 +33,7 @@ from app.controllers.shortcuts import ShortcutController
 from app.controllers.task_runner import TaskRunnerController
 from app.controllers.batch_report import BatchReportController
 from app.controllers.manual_workflow import ManualWorkflowController
+from app.controllers.presets import PresetController
 from modules.utils.exceptions import InsufficientCreditsException, ContentFlaggedException
 
 
@@ -121,6 +122,7 @@ class ComicTranslate(ComicTranslateUI):
         self.task_runner_ctrl = TaskRunnerController(self)
         self.batch_report_ctrl = BatchReportController(self)
         self.manual_workflow_ctrl = ManualWorkflowController(self)
+        self.preset_ctrl = PresetController(self)
         try:
             if self._memlogger is not None:
                 self._memlogger.emit("after_controllers_init")
@@ -242,6 +244,11 @@ class ComicTranslate(ComicTranslateUI):
         self.outline_font_color_button.clicked.connect(self.text_ctrl.on_outline_color_change)
         self.outline_width_dropdown.currentTextChanged.connect(self.text_ctrl.on_outline_width_change)
         self.outline_checkbox.stateChanged.connect(self.text_ctrl.toggle_outline_settings)
+
+        # Tool Presets
+        self.preset_panel.preset_applied.connect(self.preset_ctrl.apply_preset)
+        self.preset_panel.capture_requested.connect(self.preset_ctrl.on_capture_requested)
+        self.preset_panel.fonts_imported.connect(self.preset_ctrl.on_fonts_imported)
 
         # Page List
         self.page_list.currentItemChanged.connect(self.image_ctrl.on_page_list_current_item_changed)

--- a/modules/detection/factory.py
+++ b/modules/detection/factory.py
@@ -1,5 +1,6 @@
 from .base import DetectionEngine
 from .rtdetr_v2_onnx import RTDetrV2ONNXDetection
+from .yolov8_onnx import YOLOv8ONNXDetection
 from ..utils.device import resolve_device, torch_available
 
 
@@ -40,6 +41,7 @@ class DetectionEngineFactory:
         # Map model names to factory methods
         engine_factories = {
             'RT-DETR-v2': cls._create_rtdetr_v2,
+            'YOLOv8': cls._create_yolov8,
         }
         
         # Get the appropriate factory method, defaulting to RT-DETR-v2
@@ -71,4 +73,11 @@ class DetectionEngineFactory:
             engine.initialize(device=device)
         
         return engine
-    
+
+    @staticmethod
+    def _create_yolov8(settings, backend: str = 'onnx'):
+        """Create and initialize YOLOv8 comic detection engine (ONNX only)."""
+        device = resolve_device(settings.is_gpu_enabled(), 'onnx')
+        engine = YOLOv8ONNXDetection(settings)
+        engine.initialize(device=device)
+        return engine

--- a/modules/detection/yolov8_onnx.py
+++ b/modules/detection/yolov8_onnx.py
@@ -1,0 +1,91 @@
+import numpy as np
+import logging
+from typing import List, Tuple
+
+from .base import DetectionEngine
+from ..utils.download import ModelDownloader, ModelID
+from ..utils.device import get_providers
+
+logger = logging.getLogger(__name__)
+
+
+class YOLOv8ONNXDetection(DetectionEngine):
+    """YOLOv8-based detection engine for comic text/bubble detection.
+
+    Uses the ultralytics YOLO library to load the comic-speech-bubble-detector
+    model.  Falls back to raw ONNX inference if ultralytics is not available.
+
+    The model detects: bubble (0), text_bubble (1), text_free (2).
+    """
+
+    def __init__(self, settings=None):
+        self.model = None
+        self.device = "cpu"
+        self.settings = settings
+        self.conf_threshold = 0.3
+        self.iou_threshold = 0.45
+
+    # ------------------------------------------------------------------ #
+    # DetectionEngine interface
+    # ------------------------------------------------------------------ #
+    def initialize(self, device: str = "cpu") -> None:
+        self.device = device
+        if self.model is None:
+            ModelDownloader.get(ModelID.YOLOV8_COMIC_ONNX)
+            model_path = ModelDownloader.primary_path(ModelID.YOLOV8_COMIC_ONNX)
+            try:
+                from ultralytics import YOLO
+                self.model = YOLO(model_path)
+                self._use_ultralytics = True
+                logger.info("YOLOv8 detector loaded via ultralytics from %s", model_path)
+            except ImportError:
+                logger.warning(
+                    "ultralytics not installed. YOLOv8 detector requires "
+                    "'pip install ultralytics'. Falling back to stub."
+                )
+                self._use_ultralytics = False
+
+    def detect(
+        self, image: np.ndarray
+    ) -> Tuple[List[np.ndarray], List[np.ndarray], List[int]]:
+        """Run detection and return (boxes, scores, classes).
+
+        Args:
+            image: BGR/RGB uint8 numpy array [H, W, C].
+
+        Returns:
+            boxes   – list of [x1, y1, x2, y2] int arrays (original coords)
+            scores  – list of confidence arrays
+            classes – list of int class ids
+        """
+        if not self._use_ultralytics or self.model is None:
+            logger.error("YOLOv8 model not available — returning empty detections.")
+            return [], [], []
+
+        # Run inference
+        results = self.model.predict(
+            source=image,
+            conf=self.conf_threshold,
+            iou=self.iou_threshold,
+            device=self.device,
+            verbose=False,
+        )
+
+        boxes_list: List[np.ndarray] = []
+        scores_list: List[np.ndarray] = []
+        classes_list: List[int] = []
+
+        if results and len(results) > 0:
+            result = results[0]  # single image
+            if result.boxes is not None and len(result.boxes) > 0:
+                # xyxy in original image coordinates
+                xyxy = result.boxes.xyxy.cpu().numpy().astype(np.int32)
+                confs = result.boxes.conf.cpu().numpy()
+                cls_ids = result.boxes.cls.cpu().numpy().astype(int)
+
+                for i in range(len(xyxy)):
+                    boxes_list.append(xyxy[i])
+                    scores_list.append(np.array([confs[i]]))
+                    classes_list.append(int(cls_ids[i]))
+
+        return boxes_list, scores_list, classes_list

--- a/modules/inpainting/base.py
+++ b/modules/inpainting/base.py
@@ -52,7 +52,34 @@ class InpaintModel:
         """
         ...
 
+    def _pad_forward_raw(self, image, mask, config: Config):
+        """Run the padded forward pass and return the raw inpainted result
+        WITHOUT compositing it with the original image.
+
+        This is used by the RESIZE strategy so that compositing can happen
+        exactly once at the original (full) resolution.
+        """
+        origin_height, origin_width = image.shape[:2]
+        pad_image = pad_img_to_modulo(
+            image, mod=self.pad_mod, square=self.pad_to_square, min_size=self.min_size
+        )
+        pad_mask = pad_img_to_modulo(
+            mask, mod=self.pad_mod, square=self.pad_to_square, min_size=self.min_size
+        )
+
+        logger.info(f"final forward pad size: {pad_image.shape}")
+
+        result = self.forward(pad_image, pad_mask, config)
+        result = result[0:origin_height, 0:origin_width, :]
+
+        result, image, mask = self.forward_post_process(result, image, mask, config)
+
+        return np.clip(result, 0, 255).astype(np.uint8)
+
     def _pad_forward(self, image, mask, config: Config):
+        """Run the padded forward pass and composite the result with the
+        original image using the mask as blend weights.
+        """
         origin_height, origin_width = image.shape[:2]
         pad_image = pad_img_to_modulo(
             image, mod=self.pad_mod, square=self.pad_to_square, min_size=self.min_size
@@ -121,20 +148,29 @@ class InpaintModel:
                     logger.info(
                         f"Run resize strategy, origin size: {image.shape} forward size: {downsize_image.shape}"
                     )
-                    inpaint_result = self._pad_forward(
+                    # Get the raw inpainted result at downsampled resolution
+                    # WITHOUT compositing at low-res, so we can composite
+                    # exactly once at full resolution.
+                    inpaint_result = self._pad_forward_raw(
                         downsize_image, downsize_mask, config
                     )
 
-                    # only paste masked area result
+                    # Upscale the raw inpainted result to the original size
                     inpaint_result = imk.resize(
                         inpaint_result,
                         (origin_size[1], origin_size[0]),
                         mode=Image.Resampling.BICUBIC,
                     )
-                    original_pixel_indices = mask < 127
-                    inpaint_result[original_pixel_indices] = image[
-                        original_pixel_indices
-                    ]
+
+                    # Composite at full resolution: use the original mask to
+                    # blend upscaled inpainted pixels with original pixels.
+                    # This preserves full quality for non-masked areas.
+                    mask_blend = mask[:, :, np.newaxis].astype(np.float32) / 255.0
+                    inpaint_result = (
+                        inpaint_result.astype(np.float32) * mask_blend
+                        + image.astype(np.float32) * (1.0 - mask_blend)
+                    )
+                    inpaint_result = np.clip(inpaint_result, 0, 255).astype(np.uint8)
 
             if inpaint_result is None:
                 inpaint_result = self._pad_forward(image, mask, config)

--- a/modules/inpainting/ffc_arch.py
+++ b/modules/inpainting/ffc_arch.py
@@ -1,0 +1,604 @@
+"""
+Self-contained implementation of the LaMa FFCResNetGenerator architecture.
+
+Adapted from https://github.com/advimman/lama (saicinpainting.training.modules.ffc)
+with all external dependencies inlined.
+
+This module is used to load non-JIT checkpoints such as ``lama_large_512px.ckpt``
+from dreMaz/AnimeMangaInpainting.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# ---------------------------------------------------------------------------
+# Inlined helpers (originally from saicinpainting.training.modules.base)
+# ---------------------------------------------------------------------------
+
+def get_activation(kind: str = "relu", **kwargs) -> nn.Module:
+    """Return an activation layer by name."""
+    kind_lower = kind.lower()
+    if kind_lower == "relu":
+        return nn.ReLU(**kwargs)
+    if kind_lower == "leakyrelu" or kind_lower == "leaky_relu":
+        return nn.LeakyReLU(**kwargs)
+    if kind_lower == "tanh":
+        return nn.Tanh()
+    if kind_lower == "sigmoid":
+        return nn.Sigmoid()
+    if kind_lower == "elu":
+        return nn.ELU(**kwargs)
+    if kind_lower == "none" or kind_lower == "identity":
+        return nn.Identity()
+    raise ValueError(f"Unknown activation kind: {kind}")
+
+
+# ---------------------------------------------------------------------------
+# Squeeze-and-Excitation (inlined from saicinpainting.training.modules.squeeze_excitation)
+# ---------------------------------------------------------------------------
+
+class SELayer(nn.Module):
+    """Squeeze-and-Excitation block."""
+
+    def __init__(self, channel: int, reduction: int = 16):
+        super().__init__()
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Sequential(
+            nn.Linear(channel, channel // reduction, bias=False),
+            nn.ReLU(inplace=True),
+            nn.Linear(channel // reduction, channel, bias=False),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, c, _, _ = x.size()
+        y = self.avg_pool(x).view(b, c)
+        y = self.fc(y).view(b, c, 1, 1)
+        return x * y.expand_as(x)
+
+
+# ---------------------------------------------------------------------------
+# FFC building blocks
+# ---------------------------------------------------------------------------
+
+class FFCSE_block(nn.Module):
+    """Squeeze-and-Excitation block adapted for split local/global FFC features."""
+
+    def __init__(self, channels: int, ratio_g: float):
+        super().__init__()
+        in_cg = int(channels * ratio_g)
+        in_cl = channels - in_cg
+        r = 16
+
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.conv1 = nn.Conv2d(channels, channels // r, kernel_size=1, bias=True)
+        self.relu1 = nn.ReLU(inplace=True)
+        self.conv_a2l = None if in_cl == 0 else nn.Conv2d(channels // r, in_cl, kernel_size=1, bias=True)
+        self.conv_a2g = None if in_cg == 0 else nn.Conv2d(channels // r, in_cg, kernel_size=1, bias=True)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x):
+        x = x if isinstance(x, tuple) else (x, 0)
+        id_l, id_g = x
+
+        x = id_l if isinstance(id_g, int) else torch.cat([id_l, id_g], dim=1)
+        x = self.avgpool(x)
+        x = self.relu1(self.conv1(x))
+
+        x_l = 0 if self.conv_a2l is None else id_l * self.sigmoid(self.conv_a2l(x))
+        x_g = 0 if self.conv_a2g is None else id_g * self.sigmoid(self.conv_a2g(x))
+        return x_l, x_g
+
+
+class FourierUnit(nn.Module):
+    """Core Fourier convolution unit providing image-wide receptive field."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        groups: int = 1,
+        spatial_scale_factor=None,
+        spatial_scale_mode: str = "bilinear",
+        spectral_pos_encoding: bool = False,
+        use_se: bool = False,
+        se_kwargs: dict | None = None,
+        ffc3d: bool = False,
+        fft_norm: str = "ortho",
+    ):
+        super().__init__()
+        self.groups = groups
+
+        self.conv_layer = nn.Conv2d(
+            in_channels=in_channels * 2 + (2 if spectral_pos_encoding else 0),
+            out_channels=out_channels * 2,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            groups=self.groups,
+            bias=False,
+        )
+        self.bn = nn.BatchNorm2d(out_channels * 2)
+        self.relu = nn.ReLU(inplace=True)
+
+        self.use_se = use_se
+        if use_se:
+            if se_kwargs is None:
+                se_kwargs = {}
+            self.se = SELayer(self.conv_layer.in_channels, **se_kwargs)
+
+        self.spatial_scale_factor = spatial_scale_factor
+        self.spatial_scale_mode = spatial_scale_mode
+        self.spectral_pos_encoding = spectral_pos_encoding
+        self.ffc3d = ffc3d
+        self.fft_norm = fft_norm
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch = x.shape[0]
+
+        if self.spatial_scale_factor is not None:
+            orig_size = x.shape[-2:]
+            x = F.interpolate(
+                x,
+                scale_factor=self.spatial_scale_factor,
+                mode=self.spatial_scale_mode,
+                align_corners=False,
+            )
+
+        fft_dim = (-3, -2, -1) if self.ffc3d else (-2, -1)
+        ffted = torch.fft.rfftn(x, dim=fft_dim, norm=self.fft_norm)
+        ffted = torch.stack((ffted.real, ffted.imag), dim=-1)
+        ffted = ffted.permute(0, 1, 4, 2, 3).contiguous()  # (batch, c, 2, h, w/2+1)
+        ffted = ffted.view((batch, -1) + ffted.size()[3:])
+
+        if self.spectral_pos_encoding:
+            height, width = ffted.shape[-2:]
+            coords_vert = (
+                torch.linspace(0, 1, height)[None, None, :, None]
+                .expand(batch, 1, height, width)
+                .to(ffted)
+            )
+            coords_hor = (
+                torch.linspace(0, 1, width)[None, None, None, :]
+                .expand(batch, 1, height, width)
+                .to(ffted)
+            )
+            ffted = torch.cat((coords_vert, coords_hor, ffted), dim=1)
+
+        if self.use_se:
+            ffted = self.se(ffted)
+
+        ffted = self.conv_layer(ffted)  # (batch, c*2, h, w/2+1)
+        ffted = self.relu(self.bn(ffted))
+
+        ffted = (
+            ffted.view((batch, -1, 2) + ffted.size()[2:])
+            .permute(0, 1, 3, 4, 2)
+            .contiguous()
+        )  # (batch, c, h, w/2+1, 2)
+        ffted = torch.complex(ffted[..., 0], ffted[..., 1])
+
+        ifft_shape_slice = x.shape[-3:] if self.ffc3d else x.shape[-2:]
+        output = torch.fft.irfftn(ffted, s=ifft_shape_slice, dim=fft_dim, norm=self.fft_norm)
+
+        if self.spatial_scale_factor is not None:
+            output = F.interpolate(
+                output,
+                size=orig_size,
+                mode=self.spatial_scale_mode,
+                align_corners=False,
+            )
+
+        return output
+
+
+class SpectralTransform(nn.Module):
+    """Wraps FourierUnit with pre/post convolutions and optional LFU."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        stride: int = 1,
+        groups: int = 1,
+        enable_lfu: bool = True,
+        **fu_kwargs,
+    ):
+        super().__init__()
+        self.enable_lfu = enable_lfu
+        if stride == 2:
+            self.downsample = nn.AvgPool2d(kernel_size=(2, 2), stride=2)
+        else:
+            self.downsample = nn.Identity()
+
+        self.stride = stride
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels // 2, kernel_size=1, groups=groups, bias=False),
+            nn.BatchNorm2d(out_channels // 2),
+            nn.ReLU(inplace=True),
+        )
+        self.fu = FourierUnit(out_channels // 2, out_channels // 2, groups, **fu_kwargs)
+        if self.enable_lfu:
+            self.lfu = FourierUnit(out_channels // 2, out_channels // 2, groups)
+        self.conv2 = nn.Conv2d(
+            out_channels // 2, out_channels, kernel_size=1, groups=groups, bias=False
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.downsample(x)
+        x = self.conv1(x)
+        output = self.fu(x)
+
+        if self.enable_lfu:
+            n, c, h, w = x.shape
+            split_no = 2
+            split_s = h // split_no
+            xs = torch.cat(torch.split(x[:, : c // 4], split_s, dim=-2), dim=1).contiguous()
+            xs = torch.cat(torch.split(xs, split_s, dim=-1), dim=1).contiguous()
+            xs = self.lfu(xs)
+            xs = xs.repeat(1, 1, split_no, split_no).contiguous()
+        else:
+            xs = 0
+
+        output = self.conv2(x + output + xs)
+        return output
+
+
+class FFC(nn.Module):
+    """Fast Fourier Convolution combining local and global branches."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        ratio_gin: float,
+        ratio_gout: float,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+        groups: int = 1,
+        bias: bool = False,
+        enable_lfu: bool = True,
+        padding_type: str = "reflect",
+        gated: bool = False,
+        **spectral_kwargs,
+    ):
+        super().__init__()
+
+        assert stride == 1 or stride == 2, "Stride should be 1 or 2."
+        self.stride = stride
+
+        in_cg = int(in_channels * ratio_gin)
+        in_cl = in_channels - in_cg
+        out_cg = int(out_channels * ratio_gout)
+        out_cl = out_channels - out_cg
+
+        self.ratio_gin = ratio_gin
+        self.ratio_gout = ratio_gout
+        self.global_in_num = in_cg
+
+        module = nn.Identity if in_cl == 0 or out_cl == 0 else nn.Conv2d
+        self.convl2l = module(
+            in_cl, out_cl, kernel_size, stride, padding, dilation, groups, bias,
+            padding_mode=padding_type,
+        )
+        module = nn.Identity if in_cl == 0 or out_cg == 0 else nn.Conv2d
+        self.convl2g = module(
+            in_cl, out_cg, kernel_size, stride, padding, dilation, groups, bias,
+            padding_mode=padding_type,
+        )
+        module = nn.Identity if in_cg == 0 or out_cl == 0 else nn.Conv2d
+        self.convg2l = module(
+            in_cg, out_cl, kernel_size, stride, padding, dilation, groups, bias,
+            padding_mode=padding_type,
+        )
+        module = nn.Identity if in_cg == 0 or out_cg == 0 else SpectralTransform
+        self.convg2g = module(
+            in_cg, out_cg, stride, 1 if groups == 1 else groups // 2, enable_lfu,
+            **spectral_kwargs,
+        )
+
+        self.gated = gated
+        module = nn.Identity if in_cg == 0 or out_cl == 0 or not self.gated else nn.Conv2d
+        self.gate = module(in_channels, 2, 1)
+
+    def forward(self, x):
+        x_l, x_g = x if isinstance(x, tuple) else (x, 0)
+        out_xl, out_xg = 0, 0
+
+        if self.gated:
+            total_input_parts = [x_l]
+            if torch.is_tensor(x_g):
+                total_input_parts.append(x_g)
+            total_input = torch.cat(total_input_parts, dim=1)
+
+            gates = torch.sigmoid(self.gate(total_input))
+            g2l_gate, l2g_gate = gates.chunk(2, dim=1)
+        else:
+            g2l_gate, l2g_gate = 1, 1
+
+        if self.ratio_gout != 1:
+            out_xl = self.convl2l(x_l) + self.convg2l(x_g) * g2l_gate
+        if self.ratio_gout != 0:
+            out_xg = self.convl2g(x_l) * l2g_gate + self.convg2g(x_g)
+
+        return out_xl, out_xg
+
+
+class FFC_BN_ACT(nn.Module):
+    """FFC followed by BatchNorm and activation on both branches."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        ratio_gin: float,
+        ratio_gout: float,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+        groups: int = 1,
+        bias: bool = False,
+        norm_layer=nn.BatchNorm2d,
+        activation_layer=nn.Identity,
+        padding_type: str = "reflect",
+        enable_lfu: bool = True,
+        **kwargs,
+    ):
+        super().__init__()
+        self.ffc = FFC(
+            in_channels, out_channels, kernel_size,
+            ratio_gin, ratio_gout, stride, padding, dilation,
+            groups, bias, enable_lfu, padding_type=padding_type, **kwargs,
+        )
+        lnorm = nn.Identity if ratio_gout == 1 else norm_layer
+        gnorm = nn.Identity if ratio_gout == 0 else norm_layer
+        global_channels = int(out_channels * ratio_gout)
+        self.bn_l = lnorm(out_channels - global_channels)
+        self.bn_g = gnorm(global_channels)
+
+        lact = nn.Identity if ratio_gout == 1 else activation_layer
+        gact = nn.Identity if ratio_gout == 0 else activation_layer
+        self.act_l = lact(inplace=True)
+        self.act_g = gact(inplace=True)
+
+    def forward(self, x):
+        x_l, x_g = self.ffc(x)
+        x_l = self.act_l(self.bn_l(x_l))
+        x_g = self.act_g(self.bn_g(x_g))
+        return x_l, x_g
+
+
+class FFCResnetBlock(nn.Module):
+    """Residual block using FFC convolutions."""
+
+    def __init__(
+        self,
+        dim: int,
+        padding_type: str,
+        norm_layer,
+        activation_layer=nn.ReLU,
+        dilation: int = 1,
+        inline: bool = False,
+        **conv_kwargs,
+    ):
+        super().__init__()
+        self.conv1 = FFC_BN_ACT(
+            dim, dim, kernel_size=3, padding=dilation, dilation=dilation,
+            norm_layer=norm_layer, activation_layer=activation_layer,
+            padding_type=padding_type, **conv_kwargs,
+        )
+        self.conv2 = FFC_BN_ACT(
+            dim, dim, kernel_size=3, padding=dilation, dilation=dilation,
+            norm_layer=norm_layer, activation_layer=activation_layer,
+            padding_type=padding_type, **conv_kwargs,
+        )
+        self.inline = inline
+
+    def forward(self, x):
+        if self.inline:
+            x_l, x_g = x[:, : -self.conv1.ffc.global_in_num], x[:, -self.conv1.ffc.global_in_num :]
+        else:
+            x_l, x_g = x if isinstance(x, tuple) else (x, 0)
+
+        id_l, id_g = x_l, x_g
+
+        x_l, x_g = self.conv1((x_l, x_g))
+        x_l, x_g = self.conv2((x_l, x_g))
+
+        x_l, x_g = id_l + x_l, id_g + x_g
+        out = x_l, x_g
+        if self.inline:
+            out = torch.cat(out, dim=1)
+        return out
+
+
+class ConcatTupleLayer(nn.Module):
+    """Concatenate the local and global branches of an FFC feature tuple."""
+
+    def forward(self, x):
+        assert isinstance(x, tuple)
+        x_l, x_g = x
+        assert torch.is_tensor(x_l) or torch.is_tensor(x_g)
+        if not torch.is_tensor(x_g):
+            return x_l
+        return torch.cat(x, dim=1)
+
+
+class FFCResNetGenerator(nn.Module):
+    """Full LaMa generator using Fast Fourier Convolution ResNet blocks.
+
+    This is the architecture used in:
+      "Resolution-robust Large Mask Inpainting with Fourier Convolutions"
+      (Suvorov et al., WACV 2022)
+
+    The ``big-lama`` configuration:
+        input_nc=4, output_nc=3, ngf=64, n_downsampling=3, n_blocks=18,
+        add_out_act='sigmoid'
+
+    Args:
+        input_nc: Number of input channels (typically 4: RGB image + mask).
+        output_nc: Number of output channels (typically 3: RGB).
+        ngf: Base number of generator filters.
+        n_downsampling: Number of downsampling layers in the encoder.
+        n_blocks: Number of FFC ResNet blocks in the bottleneck.
+        norm_layer: Normalization layer constructor.
+        padding_type: Padding type for convolutions.
+        activation_layer: Activation layer constructor.
+        up_norm_layer: Normalization layer for upsampling path.
+        up_activation: Activation module instance for upsampling path.
+        init_conv_kwargs: Kwargs for the initial convolution FFC.
+        downsample_conv_kwargs: Kwargs for downsampling FFC layers.
+        resnet_conv_kwargs: Kwargs for residual FFC blocks.
+        add_out_act: Output activation — True for 'tanh', or a string name.
+        max_features: Maximum number of feature channels.
+        out_ffc: Whether to add an FFC block after upsampling.
+        out_ffc_kwargs: Kwargs for the output FFC block.
+    """
+
+    def __init__(
+        self,
+        input_nc: int,
+        output_nc: int,
+        ngf: int = 64,
+        n_downsampling: int = 3,
+        n_blocks: int = 9,
+        norm_layer=nn.BatchNorm2d,
+        padding_type: str = "reflect",
+        activation_layer=nn.ReLU,
+        up_norm_layer=nn.BatchNorm2d,
+        up_activation=nn.ReLU(True),
+        init_conv_kwargs: dict | None = None,
+        downsample_conv_kwargs: dict | None = None,
+        resnet_conv_kwargs: dict | None = None,
+        add_out_act=True,
+        max_features: int = 1024,
+        out_ffc: bool = False,
+        out_ffc_kwargs: dict | None = None,
+    ):
+        assert n_blocks >= 0
+        super().__init__()
+
+        if init_conv_kwargs is None:
+            init_conv_kwargs = {}
+        if downsample_conv_kwargs is None:
+            downsample_conv_kwargs = {}
+        if resnet_conv_kwargs is None:
+            resnet_conv_kwargs = {}
+        if out_ffc_kwargs is None:
+            out_ffc_kwargs = {}
+
+        model = [
+            nn.ReflectionPad2d(3),
+            FFC_BN_ACT(
+                input_nc, ngf, kernel_size=7, padding=0,
+                norm_layer=norm_layer, activation_layer=activation_layer,
+                **init_conv_kwargs,
+            ),
+        ]
+
+        # Downsample
+        for i in range(n_downsampling):
+            mult = 2 ** i
+            if i == n_downsampling - 1:
+                cur_conv_kwargs = dict(downsample_conv_kwargs)
+                cur_conv_kwargs["ratio_gout"] = resnet_conv_kwargs.get("ratio_gin", 0)
+            else:
+                cur_conv_kwargs = downsample_conv_kwargs
+            model += [
+                FFC_BN_ACT(
+                    min(max_features, ngf * mult),
+                    min(max_features, ngf * mult * 2),
+                    kernel_size=3, stride=2, padding=1,
+                    norm_layer=norm_layer, activation_layer=activation_layer,
+                    **cur_conv_kwargs,
+                )
+            ]
+
+        mult = 2 ** n_downsampling
+        feats_num_bottleneck = min(max_features, ngf * mult)
+
+        # ResNet blocks
+        for i in range(n_blocks):
+            cur_resblock = FFCResnetBlock(
+                feats_num_bottleneck,
+                padding_type=padding_type,
+                activation_layer=activation_layer,
+                norm_layer=norm_layer,
+                **resnet_conv_kwargs,
+            )
+            model += [cur_resblock]
+
+        model += [ConcatTupleLayer()]
+
+        # Upsample
+        for i in range(n_downsampling):
+            mult = 2 ** (n_downsampling - i)
+            model += [
+                nn.ConvTranspose2d(
+                    min(max_features, ngf * mult),
+                    min(max_features, int(ngf * mult / 2)),
+                    kernel_size=3, stride=2, padding=1, output_padding=1,
+                ),
+                up_norm_layer(min(max_features, int(ngf * mult / 2))),
+                up_activation,
+            ]
+
+        if out_ffc:
+            model += [
+                FFCResnetBlock(
+                    ngf, padding_type=padding_type, activation_layer=activation_layer,
+                    norm_layer=norm_layer, inline=True, **out_ffc_kwargs,
+                )
+            ]
+
+        model += [nn.ReflectionPad2d(3), nn.Conv2d(ngf, output_nc, kernel_size=7, padding=0)]
+        if add_out_act:
+            model.append(get_activation("tanh" if add_out_act is True else add_out_act))
+        self.model = nn.Sequential(*model)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)
+
+
+# ---------------------------------------------------------------------------
+# Factory for the big-lama / lama_large_512px configuration
+# ---------------------------------------------------------------------------
+
+def build_lama_large_generator() -> FFCResNetGenerator:
+    """Instantiate an ``FFCResNetGenerator`` with the big-lama config
+    used by ``lama_large_512px.ckpt`` (dreMaz/AnimeMangaInpainting).
+
+    Config:
+        input_nc=4, output_nc=3, ngf=64, n_downsampling=3, n_blocks=18,
+        add_out_act='sigmoid',
+        init_conv:     ratio_gin=0,    ratio_gout=0,    enable_lfu=False
+        downsample:    ratio_gin=0,    ratio_gout=0,    enable_lfu=False
+        resnet:        ratio_gin=0.75, ratio_gout=0.75, enable_lfu=False
+    """
+    return FFCResNetGenerator(
+        input_nc=4,
+        output_nc=3,
+        ngf=64,
+        n_downsampling=3,
+        n_blocks=18,
+        norm_layer=nn.BatchNorm2d,
+        padding_type="reflect",
+        activation_layer=nn.ReLU,
+        up_norm_layer=nn.BatchNorm2d,
+        up_activation=nn.ReLU(True),
+        init_conv_kwargs={"ratio_gin": 0, "ratio_gout": 0, "enable_lfu": False},
+        downsample_conv_kwargs={"ratio_gin": 0, "ratio_gout": 0, "enable_lfu": False},
+        resnet_conv_kwargs={"ratio_gin": 0.75, "ratio_gout": 0.75, "enable_lfu": False},
+        add_out_act="sigmoid",
+        max_features=1024,
+        out_ffc=False,
+        out_ffc_kwargs={},
+    )

--- a/modules/inpainting/lama_large.py
+++ b/modules/inpainting/lama_large.py
@@ -1,0 +1,335 @@
+"""
+LaMa Large 512px inpainter — uses the ``lama_large_512px.ckpt``
+checkpoint from dreMaz/AnimeMangaInpainting (fine-tuned Big LaMa
+on 300k anime/manga images).
+
+Unlike the base :class:`LaMa` inpainter that loads a TorchScript JIT
+model, this class instantiates the full :class:`FFCResNetGenerator`
+architecture and loads weights from a raw PyTorch ``state_dict``
+checkpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import imkit as imk
+import numpy as np
+from PIL import Image
+
+from ..utils.download import ModelDownloader, ModelID
+from ..utils.inpainting import (
+    boxes_from_mask,
+    norm_img,
+    pad_img_to_modulo,
+    resize_max_size,
+)
+from ..utils.torch_autocast import TorchAutocastMixin
+from .base import InpaintModel
+from .schema import Config
+
+logger = logging.getLogger(__name__)
+
+
+class LamaLarge(TorchAutocastMixin, InpaintModel):
+    """Inpainter using ``lama_large_512px.ckpt`` (PyTorch checkpoint)."""
+
+    name = "lama_large"
+    pad_mod = 8
+    preferred_backend = "torch"  # No ONNX variant available
+
+    # Per-region processing parameters for optimal quality.
+    # The model was fine-tuned at 512px; processing at 1024px gives
+    # excellent quality thanks to the 18-block big-lama architecture.
+    max_inpaint_size = 1024
+    crop_margin = 128
+
+    @staticmethod
+    def should_use_autocast(device: str) -> bool:
+        """XPU devices require float32 for the FFT path."""
+        return str(device).split(":", 1)[0].lower() != "xpu"
+
+    def init_model(self, device, **kwargs):
+        import torch
+
+        self.backend = "torch"
+
+        # Ensure checkpoint is downloaded
+        ModelDownloader.get(ModelID.LAMA_LARGE_CKPT)
+        ckpt_path = ModelDownloader.primary_path(ModelID.LAMA_LARGE_CKPT)
+
+        # Build the generator architecture
+        from .ffc_arch import build_lama_large_generator
+
+        self.model = build_lama_large_generator()
+
+        # Load checkpoint weights
+        logger.info("Loading LaMa Large checkpoint from: %s", ckpt_path)
+        checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+
+        # Handle multiple checkpoint formats:
+        # 1. BallonsTranslator / dreMaz: {'gen_state_dict': {...}}
+        # 2. PyTorch Lightning: {'state_dict': {...}} with 'generator.model.' prefix
+        # 3. Nested under 'model' key
+        # 4. Raw state_dict (OrderedDict of tensors)
+        if isinstance(checkpoint, dict) and "gen_state_dict" in checkpoint:
+            state_dict = checkpoint["gen_state_dict"]
+            logger.info("Checkpoint format: gen_state_dict (%d keys)", len(state_dict))
+        elif isinstance(checkpoint, dict) and "state_dict" in checkpoint:
+            state_dict = checkpoint["state_dict"]
+            logger.info("Checkpoint format: state_dict (%d keys)", len(state_dict))
+        elif isinstance(checkpoint, dict) and "model" in checkpoint:
+            state_dict = checkpoint["model"]
+            logger.info("Checkpoint format: model (%d keys)", len(state_dict))
+        else:
+            state_dict = checkpoint
+            logger.info("Checkpoint format: raw (%d keys)", len(state_dict))
+
+        # Strip common key prefixes to match our model's parameter names
+        cleaned_state_dict = self._clean_state_dict(state_dict)
+
+        # Load into model
+        missing, unexpected = self.model.load_state_dict(cleaned_state_dict, strict=False)
+        if missing:
+            logger.warning(
+                "LaMa Large: %d missing keys: %s",
+                len(missing),
+                missing[:10],
+            )
+        if unexpected:
+            logger.warning(
+                "LaMa Large: %d unexpected keys: %s",
+                len(unexpected),
+                unexpected[:10],
+            )
+
+        # Critical integrity check: if most keys are missing, the model
+        # is essentially running on random weights and will produce garbage.
+        total_params = len(list(self.model.state_dict().keys()))
+        if len(missing) > total_params * 0.5:
+            raise RuntimeError(
+                f"LaMa Large checkpoint loading failed: {len(missing)}/{total_params} "
+                f"model parameters have NO learned weights (checkpoint format "
+                f"mismatch?). Top-level checkpoint keys: {list(checkpoint.keys()) if isinstance(checkpoint, dict) else 'N/A'}"
+            )
+
+        self.model.to(device)
+        self.model.eval()
+
+        # Configure autocast
+        self.setup_torch_autocast(torch, device)
+        if not self.should_use_autocast(device):
+            logger.info(
+                "Disabling LaMa Large autocast on device '%s' because the FFT path requires float32.",
+                device,
+            )
+            self.use_autocast = False
+
+        logger.info("LaMa Large model initialized on device '%s'", device)
+
+    @staticmethod
+    def _clean_state_dict(state_dict: dict) -> dict:
+        """Strip known prefixes from checkpoint keys to match local model parameter names.
+
+        Tries the following prefix removals in order:
+          1. ``generator.model.`` → ``model.``  (PyTorch Lightning full key)
+          2. ``generator.``       → `` ``        (less common)
+
+        If none of the prefixes match, returns the state_dict as-is (assume
+        it already matches).
+        """
+        # Detect which prefix is present
+        prefixes_to_try = ["generator.model.", "generator."]
+
+        for prefix in prefixes_to_try:
+            if any(k.startswith(prefix) for k in state_dict):
+                # For "generator.model." -> we want "model." (our FFCResNetGenerator stores in self.model)
+                if prefix == "generator.model.":
+                    new_prefix = "model."
+                else:
+                    new_prefix = ""
+
+                cleaned = {}
+                for k, v in state_dict.items():
+                    if k.startswith(prefix):
+                        new_key = new_prefix + k[len(prefix):]
+                        cleaned[new_key] = v
+                    # Skip keys that don't start with this prefix
+                    # (e.g., discriminator, optimizer, loss weights)
+
+                if cleaned:
+                    logger.info(
+                        "Stripped prefix '%s' from %d checkpoint keys (skipped %d non-generator keys)",
+                        prefix,
+                        len(cleaned),
+                        len(state_dict) - len(cleaned),
+                    )
+                    return cleaned
+
+        # No prefix found — return as-is
+        return state_dict
+
+    @staticmethod
+    def is_downloaded() -> bool:
+        return ModelDownloader.is_downloaded(ModelID.LAMA_LARGE_CKPT)
+
+    # -----------------------------------------------------------------
+    # Override __call__ — per-region crop + resize strategy
+    # -----------------------------------------------------------------
+
+    def __call__(self, image, mask, config: Config):
+        """Per-region crop+resize inpainting for production quality.
+
+        Processing an entire 2000-3000px manga page in a single forward
+        pass forces the model to work far outside its trained resolution
+        (512px), producing blurry/smudged artefacts — especially over
+        detailed artwork like SFX text on character illustrations.
+
+        This override implements the same pattern used by
+        :class:`MIGAN`:
+
+        1. Detect individual mask regions  (``boxes_from_mask``)
+        2. Crop each region with context margin
+        3. Resize to the model's optimal resolution
+        4. Inpaint each crop individually
+        5. Resize back and paste only the masked pixels
+
+        For small images (≤ ``max_inpaint_size``) the full image is
+        processed directly.
+        """
+        import torch
+
+        ctx = torch.no_grad()
+        with ctx:
+            # Small images → process directly
+            if max(image.shape[:2]) <= self.max_inpaint_size:
+                return self._pad_forward(image, mask, config)
+
+            boxes = boxes_from_mask(mask)
+            if not boxes:
+                return self._pad_forward(image, mask, config)
+
+            crop_results = []
+            for box in boxes:
+                crop_img, crop_mask, crop_box = self._crop_box(
+                    image, mask, box,
+                    Config(hd_strategy_crop_margin=self.crop_margin),
+                )
+                origin_size = crop_img.shape[:2]
+
+                # Resize to model's optimal resolution
+                resize_img = resize_max_size(
+                    crop_img, size_limit=self.max_inpaint_size
+                )
+                resize_mask = resize_max_size(
+                    crop_mask, size_limit=self.max_inpaint_size
+                )
+
+                inpaint_result = self._pad_forward(
+                    resize_img, resize_mask, config
+                )
+
+                # Resize back to original crop size
+                inpaint_result = imk.resize(
+                    inpaint_result,
+                    (origin_size[1], origin_size[0]),
+                    mode=Image.Resampling.BICUBIC,
+                )
+
+                # Preserve original pixels outside the mask
+                original_pixel_indices = crop_mask < 127
+                inpaint_result[original_pixel_indices] = crop_img[
+                    original_pixel_indices
+                ]
+
+                crop_results.append((inpaint_result, crop_box))
+
+            inpaint_result = image.copy()
+            for crop_image, crop_box in crop_results:
+                x1, y1, x2, y2 = crop_box
+                inpaint_result[y1:y2, x1:x2, :] = crop_image
+
+            return inpaint_result
+
+    # -----------------------------------------------------------------
+    # forward — single-image neural inference
+    # -----------------------------------------------------------------
+
+    def forward(self, image, mask, config: Config):
+        """Run LaMa Large inpainting on a single (possibly cropped) patch.
+
+        Args:
+            image: [H, W, C] RGB uint8, not normalized.
+            mask:  [H, W] uint8, 255 = masked region.
+            config: Inpainting configuration.
+
+        Returns:
+            [H, W, C] RGB uint8 inpainted image (already blended).
+        """
+        import torch
+
+        # ------------------------------------------------------------------
+        # Step 1: Conservative mask dilation (3×3, 1 iteration).
+        #   Captures anti-aliased text edges without expanding into
+        #   surrounding artwork (the old 5×5 / 2× dilation was too
+        #   aggressive and damaged lineart near SFX areas).
+        # ------------------------------------------------------------------
+        mask_2d = mask.squeeze() if mask.ndim == 3 else mask
+        kernel = np.ones((3, 3), np.uint8)
+        mask_dilated = imk.dilate(mask_2d, kernel, iterations=1)
+
+        # ------------------------------------------------------------------
+        # Step 2: Normalize image & mask to float32 [0, 1]
+        # ------------------------------------------------------------------
+        image_n = norm_img(image)                            # (C, H, W)
+        mask_n = norm_img(mask_dilated)                      # (1, H, W)
+        mask_n = (mask_n > 0).astype("float32")
+
+        # ------------------------------------------------------------------
+        # Step 3: Build 4-channel input: concat(masked_RGB, mask)
+        # ------------------------------------------------------------------
+        image_t = torch.from_numpy(image_n).unsqueeze(0).to(self.device)
+        mask_t = torch.from_numpy(mask_n).unsqueeze(0).to(self.device)
+
+        masked_image = image_t * (1 - mask_t)
+        input_t = torch.cat([masked_image, mask_t], dim=1)   # (1, 4, H, W)
+
+        # ------------------------------------------------------------------
+        # Step 4: Forward pass
+        # ------------------------------------------------------------------
+        with torch.inference_mode():
+            output = self.run_with_torch_autocast(
+                torch_module=torch,
+                fn=lambda: self.model(input_t),
+                logger=logger,
+                engine_name=self.__class__.__name__,
+            )
+
+        # ------------------------------------------------------------------
+        # Step 5: Float32-precision blending
+        #   result = predicted * mask + original * (1 - mask)
+        # ------------------------------------------------------------------
+        blended = output * mask_t + image_t * (1 - mask_t)
+
+        cur_res = blended[0].permute(1, 2, 0).detach().cpu().numpy()
+        cur_res = np.clip(cur_res * 255, 0, 255).astype("uint8")
+        return cur_res
+
+    # -----------------------------------------------------------------
+    # _pad_forward — padding without redundant uint8 blending
+    # -----------------------------------------------------------------
+
+    def _pad_forward(self, image, mask, config: Config):
+        """Pad, forward, then un-pad — skip base-class uint8 blending."""
+        origin_height, origin_width = image.shape[:2]
+        pad_image = pad_img_to_modulo(
+            image, mod=self.pad_mod, square=self.pad_to_square, min_size=self.min_size
+        )
+        pad_mask = pad_img_to_modulo(
+            mask, mod=self.pad_mod, square=self.pad_to_square, min_size=self.min_size
+        )
+
+        result = self.forward(pad_image, pad_mask, config)
+        result = result[0:origin_height, 0:origin_width, :]
+        return result

--- a/modules/inpainting/manga_inpainting.py
+++ b/modules/inpainting/manga_inpainting.py
@@ -1,0 +1,594 @@
+"""
+CUHK MangaInpainting — InpaintModel Integration
+================================================
+
+Production-grade integration of the CUHK "Seamless Manga Inpainting with
+Semantics Awareness" (SIGGRAPH 2021) into the Comic-Translate inpainting
+pipeline.
+
+This module implements a **per-region context-aware** 3-stage inference pipeline:
+    1. Connected-component analysis to isolate each mask region
+    2. Per-region context analysis using MEDIAN-based flat detection
+    3. Flat regions (speech bubbles) → local color fill (white)
+    4. Complex regions → full CUHK neural pipeline
+
+Architecture:
+    - ScreenVAE encoder — Extract screentone representations
+    - SemanticInpaintGenerator — Iteratively predict structural lines + screentones
+    - MangaInpaintGenerator — Contextual-attention appearance synthesis
+
+Features:
+    - Per-region local context detection prevents screentone hallucination
+    - Automatic checkpoint download from Google Drive via ``gdown``
+    - Clean structural line extraction with aggressive noise suppression
+    - Full device-agnostic operation (CPU / CUDA / MPS / XPU)
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+from typing import Optional
+
+import numpy as np
+import imkit as imk
+
+from .base import InpaintModel
+from .schema import Config
+from ..utils.torch_autocast import TorchAutocastMixin
+from ..utils.download import models_base_dir, notify_download_event
+
+logger = logging.getLogger(__name__)
+
+# Directory where CUHK MangaInpainting checkpoints are stored
+_CHECKPOINT_DIR = os.path.join(models_base_dir, 'inpainting', 'manga-inpainting')
+
+# Google Drive file IDs for the official pre-trained models
+_GDRIVE_IDS = {
+    'mangainpaintor': '1YeVwaNfchLhy3lAA7jOLBP-W23onjy8S',
+    'screenvae': '1QaXqR4KWl_lxntSy32QpQpXb-1-EP7_L',
+}
+
+# Required checkpoint files
+_REQUIRED_FILES = {
+    'semantic_gen': 'SemanticInpaintingModel_gen.pth',
+    'manga_gen': 'MangaInpaintingModel_gen.pth',
+    'screenvae_enc': 'latest_net_enc.pth',
+}
+
+# Iterative mask erosion schedule
+_SHRINK_ITERS = 5
+
+# --- Per-region context detection tuning ---
+# Width of the analysis ring around each mask region (pixels)
+_BORDER_PX = 10
+# Minimum border samples for reliable analysis
+_MIN_BORDER_SAMPLES = 20
+# MEDIAN threshold: if median of surrounding pixels > this → flat
+# Manga speech bubbles have mostly white (240-255) with thin black border lines
+# Using MEDIAN (not mean) makes this robust to bubble-outline pixels
+_FLAT_MEDIAN_THRESHOLD = 210
+
+
+def _ensure_checkpoint_dir() -> str:
+    """Create and return the checkpoint directory path."""
+    os.makedirs(_CHECKPOINT_DIR, exist_ok=True)
+    return _CHECKPOINT_DIR
+
+
+def _get_missing_files() -> list[str]:
+    """Return list of missing checkpoint filenames."""
+    return [
+        fname for fname in _REQUIRED_FILES.values()
+        if not os.path.exists(os.path.join(_CHECKPOINT_DIR, fname))
+    ]
+
+
+def _download_checkpoints():
+    """Download CUHK MangaInpainting checkpoints from Google Drive."""
+    import tempfile
+    import zipfile
+    import shutil
+
+    try:
+        import gdown
+    except ImportError:
+        raise RuntimeError(
+            "CUHK MangaInpainting requires the 'gdown' package for automatic "
+            "checkpoint download.\n"
+            "Install it with: pip install gdown\n\n"
+            "Alternatively, manually download the checkpoints from:\n"
+            "  MangaInpainting: https://drive.google.com/file/d/1YeVwaNfchLhy3lAA7jOLBP-W23onjy8S\n"
+            "  ScreenVAE:       https://drive.google.com/file/d/1QaXqR4KWl_lxntSy32QpQpXb-1-EP7_L\n"
+            f"Extract and place the .pth files into:\n  {_CHECKPOINT_DIR}"
+        )
+
+    save_dir = _ensure_checkpoint_dir()
+
+    for archive_name, gdrive_id in _GDRIVE_IDS.items():
+        if archive_name == 'mangainpaintor':
+            needed = [_REQUIRED_FILES['semantic_gen'], _REQUIRED_FILES['manga_gen']]
+        else:
+            needed = [_REQUIRED_FILES['screenvae_enc']]
+
+        if all(os.path.exists(os.path.join(save_dir, f)) for f in needed):
+            logger.info(f"Checkpoints for '{archive_name}' already present, skipping download.")
+            continue
+
+        logger.info(f"Downloading '{archive_name}' from Google Drive (id={gdrive_id})...")
+        notify_download_event('start', f'manga-inpainting-{archive_name}')
+
+        with tempfile.TemporaryDirectory(dir=save_dir) as tmp_dir:
+            url = f"https://drive.google.com/uc?id={gdrive_id}"
+            tmp_path = os.path.join(tmp_dir, f"{archive_name}.zip")
+
+            try:
+                output = gdown.download(url, tmp_path, quiet=False)
+                if output is None:
+                    raise RuntimeError(f"gdown returned None for {archive_name}")
+            except Exception as e:
+                logger.error(f"Failed to download {archive_name}: {e}")
+                notify_download_event('end', f'manga-inpainting-{archive_name}')
+                raise RuntimeError(
+                    f"Failed to download CUHK MangaInpainting checkpoint '{archive_name}'.\n"
+                    f"Error: {e}\n\n"
+                    "Please manually download from Google Drive and extract .pth files to:\n"
+                    f"  {save_dir}"
+                ) from e
+
+            extracted = False
+            if zipfile.is_zipfile(tmp_path):
+                with zipfile.ZipFile(tmp_path, 'r') as zf:
+                    zf.extractall(tmp_dir)
+                extracted = True
+            else:
+                try:
+                    import tarfile
+                    if tarfile.is_tarfile(tmp_path):
+                        with tarfile.open(tmp_path, 'r:*') as tf:
+                            tf.extractall(tmp_dir)
+                        extracted = True
+                except Exception:
+                    pass
+
+            if not extracted:
+                if len(needed) == 1:
+                    shutil.copy2(tmp_path, os.path.join(save_dir, needed[0]))
+                else:
+                    raise RuntimeError(
+                        f"Downloaded file for '{archive_name}' is not a recognized archive."
+                    )
+            else:
+                for root, _dirs, files in os.walk(tmp_dir):
+                    for fname in files:
+                        if fname in needed:
+                            src = os.path.join(root, fname)
+                            dst = os.path.join(save_dir, fname)
+                            shutil.copy2(src, dst)
+                            logger.info(f"Extracted: {fname} → {save_dir}")
+
+        notify_download_event('end', f'manga-inpainting-{archive_name}')
+
+    still_missing = _get_missing_files()
+    if still_missing:
+        raise RuntimeError(
+            f"After download, still missing:\n"
+            + "\n".join(f"  - {f}" for f in still_missing)
+            + f"\n\nPlace these files in:\n  {save_dir}"
+        )
+
+
+# =============================================================================
+# Per-Region Context Analysis (MEDIAN-based, per connected component)
+# =============================================================================
+
+def _is_region_flat(gray: np.ndarray, region_mask: np.ndarray) -> bool:
+    """Determine if a single mask region sits inside a flat/white area.
+
+    Uses MEDIAN of surrounding pixels (robust to thin bubble outlines).
+    A typical speech bubble has:
+      - White interior (240-255)
+      - Thin black outline (0-30) — only 1-3px wide
+    The MEDIAN ignores the outline and sees the white interior.
+
+    Args:
+        gray: [H, W] uint8 grayscale image
+        region_mask: [H, W] boolean mask for ONE connected component
+
+    Returns:
+        True if the region is inside a flat/white area (speech bubble etc.)
+    """
+    mask_uint8 = region_mask.astype(np.uint8) * 255
+
+    # Create a border ring around this specific region
+    kernel_size = _BORDER_PX * 2 + 1
+    kernel = imk.get_structuring_element(imk.MORPH_ELLIPSE, (kernel_size, kernel_size))
+    dilated = imk.dilate(mask_uint8, kernel, iterations=1) > 127
+    border = dilated & (~region_mask)
+
+    border_count = int(border.sum())
+    if border_count < _MIN_BORDER_SAMPLES:
+        # Too few border pixels → assume flat (safer for text cleaning)
+        return True
+
+    border_pixels = gray[border]
+    median_val = float(np.median(border_pixels))
+
+    return median_val > _FLAT_MEDIAN_THRESHOLD
+
+
+def _fill_region_with_local_color(image: np.ndarray, region_mask: np.ndarray,
+                                  gray: np.ndarray) -> None:
+    """Fill a single flat region with the MEDIAN color of surrounding pixels.
+
+    Modifies `image` in-place. Uses median instead of mean for robustness
+    against bubble border outlines (thin black lines).
+
+    Args:
+        image: [H, W, C] uint8 RGB image (modified in-place)
+        region_mask: [H, W] boolean mask for one region
+        gray: [H, W] uint8 grayscale image
+    """
+    mask_uint8 = region_mask.astype(np.uint8) * 255
+    kernel_size = _BORDER_PX * 2 + 1
+    kernel = imk.get_structuring_element(imk.MORPH_ELLIPSE, (kernel_size, kernel_size))
+    dilated = imk.dilate(mask_uint8, kernel, iterations=1) > 127
+    border = dilated & (~region_mask)
+
+    if border.sum() == 0:
+        # Fallback: fill with white
+        if len(image.shape) == 3:
+            image[region_mask] = 255
+        else:
+            image[region_mask] = 255
+        return
+
+    if len(image.shape) == 3:
+        for c in range(image.shape[2]):
+            channel_border = image[:, :, c][border]
+            fill_val = int(np.median(channel_border))
+            image[:, :, c][region_mask] = fill_val
+    else:
+        fill_val = int(np.median(image[border]))
+        image[region_mask] = fill_val
+
+
+# =============================================================================
+# Structural Line Extraction (aggressive noise suppression)
+# =============================================================================
+
+def _extract_structural_lines(grayscale: np.ndarray) -> np.ndarray:
+    """Extract structural lines from a grayscale manga image.
+
+    Uses aggressive noise suppression to prevent screentone from being
+    misidentified as structural lines (which causes the semantic model
+    to hallucinate screentone patterns).
+
+    Args:
+        grayscale: [H, W] uint8 grayscale image
+
+    Returns:
+        [H, W] uint8 binary line image (255 = line, 0 = background)
+    """
+    # Very strong blur to eliminate screentone patterns completely
+    smoothed = imk.gaussian_blur(grayscale, radius=3.0)
+
+    # Sobel gradients via numpy
+    img_float = smoothed.astype(np.float64)
+    kx = np.array([[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]], dtype=np.float64)
+    ky = np.array([[-1, -2, -1], [0, 0, 0], [1, 2, 1]], dtype=np.float64)
+
+    padded = np.pad(img_float, 1, mode='reflect')
+    h, w = img_float.shape
+    sx = np.zeros_like(img_float)
+    sy = np.zeros_like(img_float)
+    for dy in range(3):
+        for dx in range(3):
+            sx += padded[dy:dy + h, dx:dx + w] * kx[dy, dx]
+            sy += padded[dy:dy + h, dx:dx + w] * ky[dy, dx]
+
+    magnitude = np.hypot(sx, sy)
+    max_val = magnitude.max()
+    if max_val > 0:
+        magnitude = (magnitude / max_val * 255).astype(np.uint8)
+    else:
+        return np.zeros_like(grayscale)
+
+    # Very high threshold — only keep strong definitive lines
+    threshold = max(60, int(np.mean(magnitude) + np.std(magnitude) * 1.5))
+    edges = np.where(magnitude > threshold, np.uint8(255), np.uint8(0))
+
+    # Morphological close to connect line fragments
+    close_kernel = imk.get_structuring_element(imk.MORPH_RECT, (2, 2))
+    edges = imk.morphology_ex(edges, imk.MORPH_CLOSE, close_kernel)
+
+    return edges
+
+
+# =============================================================================
+# MangaInpainting Model
+# =============================================================================
+
+class MangaInpainting(TorchAutocastMixin, InpaintModel):
+    """CUHK MangaInpainting — Per-Region Context-Aware Manga Inpainting.
+
+    For each INDIVIDUAL masked region (connected component):
+      - Analyzes local context using MEDIAN of surrounding pixels
+      - Flat/white regions (bubbles) → filled with surrounding median color
+      - Complex artwork → full 3-stage CUHK neural pipeline
+
+    The per-region approach ensures speech bubbles get clean white fill
+    regardless of what other regions on the page look like.
+    """
+
+    name = "manga_inpainting"
+    pad_mod = 8
+    pad_to_square = False
+    preferred_backend = "torch"
+
+    def init_model(self, device, **kwargs):
+        """Initialize all three sub-networks and load pre-trained weights."""
+        import torch
+
+        missing = _get_missing_files()
+        if missing:
+            logger.info(f"Missing {len(missing)} checkpoint file(s), initiating download...")
+            _ensure_checkpoint_dir()
+            _download_checkpoints()
+
+        from .manga_inpainting_arch import (
+            build_screenvae_encoder,
+            build_semantic_generator,
+            build_manga_generator,
+            Erosion2d,
+        )
+
+        logger.info("Building CUHK MangaInpainting models...")
+        self.screenvae_enc = build_screenvae_encoder(device)
+        self.semantic_gen = build_semantic_generator(device)
+        self.manga_gen = build_manga_generator(device)
+        self.erosion = Erosion2d(1, 1, 3, soft_max=False).to(device)
+
+        self._load_weights(device, torch)
+
+        for model in [self.screenvae_enc, self.semantic_gen, self.manga_gen]:
+            for param in model.parameters():
+                param.requires_grad = False
+
+        self.setup_torch_autocast(torch, device)
+        logger.info(f"CUHK MangaInpainting models loaded on device={device}")
+
+    def _load_weights(self, device, torch_module):
+        """Load pre-trained weights with DataParallel-aware state dict handling.
+
+        CRITICAL: The ScreenVAE checkpoint keys have 'model.' prefix because the
+        ScreenVAEEncoder wraps its Sequential in self.model. Loading into
+        self.screenvae_enc (not .model) preserves the correct key alignment.
+        """
+        import torch
+
+        save_dir = _CHECKPOINT_DIR
+
+        # ScreenVAE encoder
+        # Checkpoint keys: model.1.weight, model.1.bias, ...
+        # screenvae_enc.state_dict() keys: model.1.weight, model.1.bias, ...  ← MATCH
+        # screenvae_enc.model.state_dict() keys: 1.weight, 1.bias, ...  ← NO MATCH (wrong level!)
+        enc_path = os.path.join(save_dir, _REQUIRED_FILES['screenvae_enc'])
+        logger.info(f"Loading ScreenVAE encoder from: {enc_path}")
+        enc_state = torch.load(enc_path, map_location='cpu', weights_only=False)
+        enc_state = _strip_module_prefix(enc_state)
+        missing, unexpected = self.screenvae_enc.load_state_dict(enc_state, strict=False)
+        if missing:
+            logger.warning(f"ScreenVAE missing keys: {len(missing)} — {missing[:3]}")
+        if unexpected:
+            logger.warning(f"ScreenVAE unexpected keys: {len(unexpected)} — {unexpected[:3]}")
+        loaded = len(self.screenvae_enc.state_dict()) - len(missing)
+        logger.info(f"ScreenVAE: {loaded}/{len(self.screenvae_enc.state_dict())} keys loaded")
+        del enc_state
+
+        # SemanticInpaintGenerator
+        sem_path = os.path.join(save_dir, _REQUIRED_FILES['semantic_gen'])
+        logger.info(f"Loading SemanticInpaintGenerator from: {sem_path}")
+        sem_data = torch.load(sem_path, map_location='cpu', weights_only=False)
+        sem_state = sem_data.get('generator', sem_data) if isinstance(sem_data, dict) else sem_data
+        sem_state = _strip_module_prefix(sem_state)
+        missing, unexpected = self.semantic_gen.load_state_dict(sem_state, strict=False)
+        if missing:
+            logger.warning(f"SemanticGen missing keys: {len(missing)} — {missing[:3]}")
+        loaded = len(self.semantic_gen.state_dict()) - len(missing)
+        logger.info(f"SemanticGen: {loaded}/{len(self.semantic_gen.state_dict())} keys loaded")
+        del sem_data, sem_state
+
+        # MangaInpaintGenerator
+        manga_path = os.path.join(save_dir, _REQUIRED_FILES['manga_gen'])
+        logger.info(f"Loading MangaInpaintGenerator from: {manga_path}")
+        manga_data = torch.load(manga_path, map_location='cpu', weights_only=False)
+        manga_state = manga_data.get('generator', manga_data) if isinstance(manga_data, dict) else manga_data
+        manga_state = _strip_module_prefix(manga_state)
+        missing, unexpected = self.manga_gen.load_state_dict(manga_state, strict=False)
+        if missing:
+            logger.warning(f"MangaGen missing keys: {len(missing)} — {missing[:3]}")
+        loaded = len(self.manga_gen.state_dict()) - len(missing)
+        logger.info(f"MangaGen: {loaded}/{len(self.manga_gen.state_dict())} keys loaded")
+
+    @staticmethod
+    def is_downloaded() -> bool:
+        return len(_get_missing_files()) == 0
+
+    def forward(self, image: np.ndarray, mask: np.ndarray, config: Config) -> np.ndarray:
+        """Per-region context-aware CUHK MangaInpainting.
+
+        Uses connected-component analysis to process each mask region
+        INDEPENDENTLY:
+          - Speech bubbles → clean fill with surrounding median color
+          - Complex artwork → full CUHK 3-stage neural pipeline
+
+        Args:
+            image: [H, W, C] RGB uint8
+            mask: [H, W] or [H, W, 1] uint8 mask (255 = inpaint region)
+
+        Returns:
+            [H, W, C] RGB uint8 inpainted result
+        """
+        # Normalize mask to 2D
+        mask_2d = mask[:, :, 0] if len(mask.shape) == 3 else mask
+        mask_bool = mask_2d > 127
+
+        if not mask_bool.any():
+            return image.copy()
+
+        # Grayscale for analysis
+        if len(image.shape) == 3 and image.shape[2] >= 3:
+            gray = imk.to_gray(image)
+        else:
+            gray = image if len(image.shape) == 2 else image[:, :, 0]
+
+        # =================================================================
+        # PER-REGION analysis via connected components
+        # =================================================================
+        mask_uint8 = mask_bool.astype(np.uint8) * 255
+        num_labels, labels, stats, centroids = imk.connected_components_with_stats(
+            mask_uint8, connectivity=4
+        )
+
+        result = image.copy()
+        neural_mask = np.zeros_like(mask_2d, dtype=np.uint8)  # regions needing neural pipeline
+        flat_count = 0
+        neural_count = 0
+
+        for label_id in range(1, num_labels):  # skip background (0)
+            region_mask = labels == label_id
+
+            # Skip tiny regions (< 10 pixels — likely noise)
+            region_area = int(region_mask.sum())
+            if region_area < 10:
+                # Fill tiny regions with surrounding color
+                _fill_region_with_local_color(result, region_mask, gray)
+                flat_count += 1
+                continue
+
+            if _is_region_flat(gray, region_mask):
+                # FLAT — fill with median surrounding color
+                _fill_region_with_local_color(result, region_mask, gray)
+                flat_count += 1
+            else:
+                # COMPLEX — mark for neural pipeline
+                neural_mask[region_mask] = 255
+                neural_count += 1
+
+        logger.info(
+            f"CUHK MangaInpainting: {num_labels - 1} region(s) analyzed: "
+            f"{flat_count} flat (local fill), {neural_count} complex (neural pipeline)"
+        )
+
+        # =================================================================
+        # Run neural pipeline ONCE for all complex regions combined
+        # =================================================================
+        if neural_count > 0 and neural_mask.any():
+            neural_result = self._run_cuhk_pipeline(image, gray, neural_mask, config)
+            # Composite neural results into the output
+            neural_bool = neural_mask > 127
+            result[neural_bool] = neural_result[neural_bool]
+
+        return result
+
+    def _run_cuhk_pipeline(self, image: np.ndarray, gray: np.ndarray,
+                           mask_2d: np.ndarray, config: Config) -> np.ndarray:
+        """Run the full 3-stage CUHK MangaInpainting neural pipeline.
+
+        Used only for complex artwork regions.
+
+        Args:
+            image: [H, W, C] RGB uint8
+            gray: [H, W] uint8 grayscale
+            mask_2d: [H, W] uint8 mask (255 = complex regions only)
+            config: Inpainting config
+
+        Returns:
+            [H, W, C] RGB uint8 inpainted result
+        """
+        import torch
+
+        device = self.device
+        lines = _extract_structural_lines(gray)
+
+        gray_norm = gray.astype(np.float32) / 127.5 - 1.0
+        lines_norm = lines.astype(np.float32) / 127.5 - 1.0
+        mask_norm = (mask_2d > 127).astype(np.float32)
+
+        gray_t = torch.from_numpy(gray_norm).unsqueeze(0).unsqueeze(0).to(device)
+        lines_t = torch.from_numpy(lines_norm).unsqueeze(0).unsqueeze(0).to(device)
+        mask_t = torch.from_numpy(mask_norm).unsqueeze(0).unsqueeze(0).to(device)
+
+        # Mask dilation
+        from .manga_inpainting_arch import Dilation2d
+        dilate = Dilation2d(1, 1, 3, soft_max=False).to(device)
+        mask_t = dilate(mask_t, iterations=2)
+
+        manga_masked = gray_t * (1 - mask_t) + mask_t
+        lines_masked = lines_t * (1 - mask_t) + mask_t
+
+        def _run_pipeline():
+            # Stage 1: ScreenVAE encoding
+            line_signed = torch.sign(lines_masked)
+            manga_clamped = torch.clamp(manga_masked + (1 - line_signed), -1, 1)
+            enc_input = torch.cat([manga_clamped, line_signed], dim=1)
+            enc_output = self.screenvae_enc(enc_input)
+            screen_masked, _logvar = torch.split(enc_output, 4, dim=1)
+
+            # Stage 2: Semantic inpainting (iterative)
+            lines_masked_2 = lines_t * (1 - mask_t) + mask_t
+            screen_current = screen_masked.clone()
+            lines_current = lines_masked_2.clone()
+            noise = torch.randn_like(mask_t)
+
+            grained = 1.0 / _SHRINK_ITERS
+            erosion_masks = [mask_t.clone()]
+            eroded = mask_t.clone()
+            for t in range(1, _SHRINK_ITERS):
+                target_area = mask_t.sum() * (1 - grained * t)
+                while eroded.sum() > target_area:
+                    eroded = self.erosion(eroded, iterations=3)
+                erosion_masks.append(eroded.clone())
+
+            for nmask in erosion_masks:
+                combined_mask = (mask_t + nmask) / 2.0
+                inputs = torch.cat([screen_current, lines_current, combined_mask, noise], dim=1)
+                screen_pred, lines_pred = self.semantic_gen(inputs)
+                screen_current = screen_masked * (1 - mask_t) + screen_pred * mask_t
+                lines_current = lines_masked_2 * (1 - mask_t) + lines_pred * mask_t
+
+            # Stage 3: Appearance synthesis
+            hints = torch.cat([screen_current, lines_current], dim=1)
+            images_masked = gray_t * (1 - mask_t).float()
+            gen_input = torch.cat([images_masked, hints], dim=1)
+            output = self.manga_gen(gen_input, mask_t)
+            output_merged = output * mask_t + gray_t * (1 - mask_t)
+            return output_merged
+
+        result_t = self.run_with_torch_autocast(
+            torch_module=torch,
+            fn=_run_pipeline,
+            logger=logger,
+            engine_name="MangaInpainting",
+        )
+
+        result_np = result_t.squeeze().cpu().numpy()
+        result_np = np.clip((result_np + 1) * 127.5, 0, 255).astype(np.uint8)
+        result_rgb = np.stack([result_np] * 3, axis=-1)
+        return result_rgb
+
+
+def _strip_module_prefix(state_dict: dict) -> dict:
+    """Strip 'module.' prefix from DataParallel state dict keys."""
+    cleaned = {}
+    for key, value in state_dict.items():
+        new_key = key.replace('module.', '', 1) if key.startswith('module.') else key
+        cleaned[new_key] = value
+    return cleaned
+
+
+try:
+    import torch
+except ImportError:
+    pass

--- a/modules/inpainting/manga_inpainting_arch.py
+++ b/modules/inpainting/manga_inpainting_arch.py
@@ -1,0 +1,975 @@
+"""
+CUHK MangaInpainting Architecture Components
+=============================================
+
+Full architecture implementation ported from:
+    https://github.com/msxie92/MangaInpainting
+
+    "Seamless Manga Inpainting with Semantics Awareness"
+    Minshan Xie et al., SIGGRAPH 2021
+
+All components are made device-agnostic (removed hardcoded .cuda() calls)
+and adapted for integration with the Comic-Translate inpainting pipeline.
+
+Components:
+    - Utility functions (patch extraction, padding, reduction)
+    - Morphological operations (Dilation2d, Erosion2d)
+    - ScreenVAE encoder (ResnetGenerator)
+    - SemanticInpaintGenerator (dual-head encoder-decoder)
+    - MangaInpaintGenerator (two-branch with ContextualAttention)
+"""
+
+from __future__ import annotations
+
+import math
+import functools
+import numpy as np
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.utils import spectral_norm as spectral_norm_fn
+from torch.nn.utils import weight_norm as weight_norm_fn
+from torch.nn.modules.normalization import LayerNorm
+
+
+# =============================================================================
+# Utility Functions (from utils/tools.py)
+# =============================================================================
+
+def same_padding(images: torch.Tensor, ksizes, strides, rates) -> torch.Tensor:
+    """Apply same-padding to a batch of images for patch extraction."""
+    assert len(images.size()) == 4
+    batch_size, channel, rows, cols = images.size()
+    out_rows = (rows + strides[0] - 1) // strides[0]
+    out_cols = (cols + strides[1] - 1) // strides[1]
+    effective_k_row = (ksizes[0] - 1) * rates[0] + 1
+    effective_k_col = (ksizes[1] - 1) * rates[1] + 1
+    padding_rows = max(0, (out_rows - 1) * strides[0] + effective_k_row - rows)
+    padding_cols = max(0, (out_cols - 1) * strides[1] + effective_k_col - cols)
+    padding_top = int(padding_rows / 2.)
+    padding_left = int(padding_cols / 2.)
+    padding_bottom = padding_rows - padding_top
+    padding_right = padding_cols - padding_left
+    paddings = (padding_left, padding_right, padding_top, padding_bottom)
+    images = torch.nn.ZeroPad2d(paddings)(images)
+    return images
+
+
+def extract_image_patches(images: torch.Tensor, ksizes, strides, rates,
+                          padding: str = 'same') -> torch.Tensor:
+    """Extract patches from images and flatten into the channel dimension.
+
+    Args:
+        images: [B, C, H, W]
+        ksizes: [kH, kW]
+        strides: [sH, sW]
+        rates: [dH, dW]
+        padding: 'same' or 'valid'
+
+    Returns:
+        Tensor of shape [B, C*kH*kW, L] where L is the number of patches.
+    """
+    assert len(images.size()) == 4
+    assert padding in ['same', 'valid']
+
+    if padding == 'same':
+        images = same_padding(images, ksizes, strides, rates)
+
+    unfold = torch.nn.Unfold(
+        kernel_size=ksizes, dilation=rates, padding=0, stride=strides
+    )
+    return unfold(images)
+
+
+def reduce_mean(x: torch.Tensor, axis=None, keepdim: bool = False) -> torch.Tensor:
+    """Reduce mean over specified axes."""
+    if not axis:
+        axis = range(len(x.shape))
+    for i in sorted(axis, reverse=True):
+        x = torch.mean(x, dim=i, keepdim=keepdim)
+    return x
+
+
+def reduce_sum(x: torch.Tensor, axis=None, keepdim: bool = False) -> torch.Tensor:
+    """Reduce sum over specified axes."""
+    if not axis:
+        axis = range(len(x.shape))
+    for i in sorted(axis, reverse=True):
+        x = torch.sum(x, dim=i, keepdim=keepdim)
+    return x
+
+
+# =============================================================================
+# Morphological Operations (from src/morphology.py)
+# =============================================================================
+
+def _fixed_padding(inputs: torch.Tensor, kernel_size: int, dilation: int = 1) -> torch.Tensor:
+    """Apply symmetric padding for morphological operations."""
+    kernel_size_effective = kernel_size + (kernel_size - 1) * (dilation - 1)
+    pad_total = kernel_size_effective - 1
+    pad_beg = pad_total // 2
+    pad_end = pad_total - pad_beg
+    return F.pad(inputs, (pad_beg, pad_end, pad_beg, pad_end), mode='replicate')
+
+
+class Morphology(nn.Module):
+    """Base class for differentiable morphological operators.
+
+    Supports stride=1, dilation=1, square kernels, and 'same' padding.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int = 5,
+                 soft_max: bool = True, beta: float = 15, op_type: str = 'dilation2d'):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.soft_max = soft_max
+        self.beta = beta
+        self.op_type = op_type
+        self.unfold = nn.Unfold(kernel_size, dilation=1, padding=0, stride=1)
+
+    def forward(self, x: torch.Tensor, iterations: int = 1) -> torch.Tensor:
+        for _ in range(iterations):
+            x = self._one_iter(x)
+        return x
+
+    def _one_iter(self, x: torch.Tensor) -> torch.Tensor:
+        H, W = x.shape[-2:]
+        x = _fixed_padding(x, self.kernel_size, dilation=1)
+        x = self.unfold(x)           # (B, Cin*kH*kW, L)
+        x = x.unsqueeze(1)           # (B, 1, Cin*kH*kW, L)
+
+        if self.op_type == 'erosion2d':
+            x = -1 * x
+        elif self.op_type != 'dilation2d':
+            raise ValueError(f"Unknown op_type: {self.op_type}")
+
+        if not self.soft_max:
+            x, _ = torch.max(x, dim=2, keepdim=False)
+        else:
+            x = torch.logsumexp(x * self.beta, dim=2, keepdim=False) / self.beta
+
+        if self.op_type == 'erosion2d':
+            x = -1 * x
+
+        return x.view(-1, self.out_channels, H, W)
+
+
+class Dilation2d(Morphology):
+    """Differentiable 2D dilation operator."""
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int = 5,
+                 soft_max: bool = True, beta: float = 20):
+        super().__init__(in_channels, out_channels, kernel_size, soft_max, beta, 'dilation2d')
+
+
+class Erosion2d(Morphology):
+    """Differentiable 2D erosion operator."""
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int = 5,
+                 soft_max: bool = True, beta: float = 20):
+        super().__init__(in_channels, out_channels, kernel_size, soft_max, beta, 'erosion2d')
+
+
+# =============================================================================
+# Layer Helpers (from src/networks.py)
+# =============================================================================
+
+class LayerNormWrapper(nn.Module):
+    """Device-agnostic LayerNorm wrapper.
+
+    Original CUHK code hardcodes .cuda() — this version uses F.layer_norm
+    which is inherently device-agnostic.
+    """
+
+    def __init__(self, num_features: int):
+        super().__init__()
+        self.num_features = int(num_features)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shape = [self.num_features, x.size(2), x.size(3)]
+        return F.layer_norm(x, shape)
+
+
+def _spectral_norm(module: nn.Module, mode: bool = True) -> nn.Module:
+    """Conditionally apply spectral normalization."""
+    if mode:
+        return nn.utils.spectral_norm(module)
+    return module
+
+
+# =============================================================================
+# Conv2dBlock & ResnetBlock (from src/networks.py — CUHK variant)
+# =============================================================================
+
+class Conv2dBlock(nn.Module):
+    """Convolutional block with configurable padding, normalization, and activation.
+
+    Used by MangaInpaintGenerator for gen_conv / gen_deconv operations.
+    """
+
+    def __init__(self, input_dim: int, output_dim: int, kernel_size: int,
+                 stride: int, padding: int = 0, conv_padding: int = 0,
+                 dilation: int = 1, weight_norm: str = 'none', norm: str = 'none',
+                 activation: str = 'relu', pad_type: str = 'replicate',
+                 transpose: bool = False):
+        super().__init__()
+        self.use_bias = True
+
+        # External padding module
+        if pad_type == 'reflect':
+            self.pad = nn.ReflectionPad2d(padding) if padding > 0 else None
+        elif pad_type == 'replicate':
+            self.pad = nn.ReplicationPad2d(padding) if padding > 0 else None
+        elif pad_type == 'zero':
+            self.pad = nn.ZeroPad2d(padding) if padding > 0 else None
+        elif pad_type == 'none':
+            self.pad = None
+        else:
+            raise ValueError(f"Unsupported padding type: {pad_type}")
+
+        # Normalization
+        if norm == 'bn':
+            self.norm = nn.BatchNorm2d(output_dim)
+        elif norm == 'in':
+            self.norm = nn.InstanceNorm2d(output_dim)
+        elif norm == 'ln':
+            self.norm = LayerNormWrapper(output_dim)
+        elif norm == 'none':
+            self.norm = None
+        else:
+            raise ValueError(f"Unsupported normalization: {norm}")
+
+        # Weight normalization
+        if weight_norm == 'sn':
+            self.weight_norm_fn = spectral_norm_fn
+        elif weight_norm == 'wn':
+            self.weight_norm_fn = weight_norm_fn
+        elif weight_norm == 'none':
+            self.weight_norm_fn = None
+        else:
+            raise ValueError(f"Unsupported weight norm: {weight_norm}")
+
+        # Activation
+        if activation == 'relu':
+            self.activation = nn.ReLU(inplace=True)
+        elif activation == 'elu':
+            self.activation = nn.ELU(inplace=True)
+        elif activation == 'lrelu':
+            self.activation = nn.LeakyReLU(0.2, inplace=True)
+        elif activation == 'prelu':
+            self.activation = nn.PReLU()
+        elif activation == 'selu':
+            self.activation = nn.SELU(inplace=True)
+        elif activation == 'tanh':
+            self.activation = nn.Tanh()
+        elif activation == 'none':
+            self.activation = None
+        else:
+            raise ValueError(f"Unsupported activation: {activation}")
+
+        # Convolution
+        if transpose:
+            self.conv = nn.ConvTranspose2d(
+                input_dim, output_dim, kernel_size, stride,
+                padding=conv_padding, output_padding=conv_padding,
+                dilation=dilation, bias=self.use_bias
+            )
+        else:
+            self.conv = nn.Conv2d(
+                input_dim, output_dim, kernel_size, stride,
+                padding=conv_padding, dilation=dilation, bias=self.use_bias
+            )
+
+        if self.weight_norm_fn:
+            self.conv = self.weight_norm_fn(self.conv)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.pad:
+            x = self.conv(self.pad(x))
+        else:
+            x = self.conv(x)
+        if self.norm:
+            x = self.norm(x)
+        if self.activation:
+            x = self.activation(x)
+        return x
+
+
+class CUHKResnetBlock(nn.Module):
+    """Residual block used by SemanticInpaintGenerator.
+
+    Distinct from the ScreenVAE ResnetBlock — uses spectral norm and
+    LayerNormWrapper instead of configurable norm layers.
+    """
+
+    def __init__(self, dim: int, dilation: int = 1,
+                 use_spectral_norm: bool = False, use_instance: bool = False):
+        super().__init__()
+        if use_instance:
+            self.conv_block = nn.Sequential(
+                nn.ReflectionPad2d(dilation),
+                _spectral_norm(nn.Conv2d(
+                    dim, dim, kernel_size=3, padding=0,
+                    dilation=dilation, bias=not use_spectral_norm
+                ), use_spectral_norm),
+                LayerNormWrapper(dim),
+                nn.ReLU(True),
+                nn.ReflectionPad2d(1),
+                _spectral_norm(nn.Conv2d(
+                    dim, dim, kernel_size=3, padding=0,
+                    dilation=1, bias=not use_spectral_norm
+                ), use_spectral_norm),
+                LayerNormWrapper(dim),
+            )
+        else:
+            self.conv_block = nn.Sequential(
+                nn.ReflectionPad2d(dilation),
+                _spectral_norm(nn.Conv2d(
+                    dim, dim, kernel_size=3, padding=0,
+                    dilation=dilation, bias=not use_spectral_norm
+                ), use_spectral_norm),
+                nn.ReLU(True),
+                nn.ReflectionPad2d(1),
+                _spectral_norm(nn.Conv2d(
+                    dim, dim, kernel_size=3, padding=0,
+                    dilation=1, bias=not use_spectral_norm
+                ), use_spectral_norm),
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.conv_block(x)
+
+
+def gen_conv(input_dim: int, output_dim: int, kernel_size: int = 3,
+             stride: int = 1, padding: int = 0, rate: int = 1,
+             activation: str = 'elu') -> Conv2dBlock:
+    """Create a standard convolutional block for MangaInpaintGenerator."""
+    return Conv2dBlock(
+        input_dim, output_dim, kernel_size, stride,
+        padding=padding, dilation=rate, activation=activation
+    )
+
+
+def gen_deconv(input_dim: int, output_dim: int, kernel_size: int = 3,
+               stride: int = 1, padding: int = 0, rate: int = 1,
+               activation: str = 'elu') -> Conv2dBlock:
+    """Create a transposed convolutional block for MangaInpaintGenerator."""
+    return Conv2dBlock(
+        input_dim, output_dim, kernel_size, stride,
+        conv_padding=padding, dilation=rate,
+        activation=activation, transpose=True
+    )
+
+
+# =============================================================================
+# Contextual Attention (from src/networks.py)
+# =============================================================================
+
+class ContextualAttention(nn.Module):
+    """Patch-based contextual attention for texture borrowing.
+
+    From: "Generative Image Inpainting with Contextual Attention", Yu et al.
+    Adapted for device-agnostic operation.
+    """
+
+    def __init__(self, ksize: int = 3, stride: int = 1, rate: int = 1,
+                 fuse_k: int = 3, softmax_scale: float = 10, fuse: bool = False):
+        super().__init__()
+        self.ksize = ksize
+        self.stride = stride
+        self.rate = rate
+        self.fuse_k = fuse_k
+        self.softmax_scale = softmax_scale
+        self.fuse = fuse
+
+    def forward(self, f: torch.Tensor, b: torch.Tensor,
+                mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+        """Contextual attention forward pass.
+
+        Args:
+            f: Foreground features [B, C, H, W]
+            b: Background features [B, C, H, W]
+            mask: Binary mask [B, 1, H_orig, W_orig]
+
+        Returns:
+            (attended_features, offsets)
+        """
+        raw_int_fs = list(f.size())
+        raw_int_bs = list(b.size())
+
+        # Extract patches from background at original scale (for reconstruction)
+        kernel = 2 * self.rate
+        raw_w = extract_image_patches(
+            b, ksizes=[kernel, kernel],
+            strides=[self.rate * self.stride, self.rate * self.stride],
+            rates=[1, 1], padding='same'
+        )
+        raw_w = raw_w.view(raw_int_bs[0], raw_int_bs[1], kernel, kernel, -1)
+        raw_w = raw_w.permute(0, 4, 1, 2, 3)
+        raw_w_groups = torch.split(raw_w, 1, dim=0)
+
+        # Downscale foreground and background for matching
+        f = F.interpolate(f, scale_factor=1. / self.rate, mode='nearest')
+        b = F.interpolate(b, scale_factor=1. / self.rate, mode='nearest')
+        int_fs = list(f.size())
+        int_bs = list(b.size())
+        f_groups = torch.split(f, 1, dim=0)
+
+        # Extract patches from downscaled background (for matching)
+        w = extract_image_patches(
+            b, ksizes=[self.ksize, self.ksize],
+            strides=[self.stride, self.stride],
+            rates=[1, 1], padding='same'
+        )
+        w = w.view(int_bs[0], int_bs[1], self.ksize, self.ksize, -1)
+        w = w.permute(0, 4, 1, 2, 3)
+        w_groups = torch.split(w, 1, dim=0)
+
+        # Process mask
+        if mask is None:
+            mask = torch.zeros([int_bs[0], 1, int_bs[2], int_bs[3]], device=f.device)
+        else:
+            mask = F.interpolate(mask, scale_factor=1. / (4 * self.rate), mode='nearest')
+
+        int_ms = list(mask.size())
+        m = extract_image_patches(
+            mask, ksizes=[self.ksize, self.ksize],
+            strides=[self.stride, self.stride],
+            rates=[1, 1], padding='same'
+        )
+        m = m.view(int_ms[0], int_ms[1], self.ksize, self.ksize, -1)
+        m = m.permute(0, 4, 1, 2, 3)
+        m = m[0]
+        mm = (reduce_mean(m, axis=[1, 2, 3], keepdim=True) == 0.).to(torch.float32)
+        mm = mm.permute(1, 0, 2, 3)
+
+        y = []
+        offsets = []
+        k = self.fuse_k
+        scale = self.softmax_scale
+        fuse_weight = torch.eye(k, device=f.device).view(1, 1, k, k)
+
+        for xi, wi, raw_wi in zip(f_groups, w_groups, raw_w_groups):
+            escape_NaN = torch.FloatTensor([1e-4]).to(f.device)
+            wi = wi[0]
+            max_wi = torch.sqrt(
+                reduce_sum(torch.pow(wi, 2) + escape_NaN, axis=[1, 2, 3], keepdim=True)
+            )
+            wi_normed = wi / max_wi
+
+            xi = same_padding(xi, [self.ksize, self.ksize], [1, 1], [1, 1])
+            yi = F.conv2d(xi, wi_normed, stride=1)
+
+            if self.fuse:
+                yi = yi.view(1, 1, int_bs[2] * int_bs[3], int_fs[2] * int_fs[3])
+                yi = same_padding(yi, [k, k], [1, 1], [1, 1])
+                yi = F.conv2d(yi, fuse_weight, stride=1)
+                yi = yi.contiguous().view(1, int_bs[2], int_bs[3], int_fs[2], int_fs[3])
+                yi = yi.permute(0, 2, 1, 4, 3)
+                yi = yi.contiguous().view(1, 1, int_bs[2] * int_bs[3], int_fs[2] * int_fs[3])
+                yi = same_padding(yi, [k, k], [1, 1], [1, 1])
+                yi = F.conv2d(yi, fuse_weight, stride=1)
+                yi = yi.contiguous().view(1, int_bs[3], int_bs[2], int_fs[3], int_fs[2])
+                yi = yi.permute(0, 2, 1, 4, 3).contiguous()
+
+            yi = yi.view(1, int_bs[2] * int_bs[3], int_fs[2], int_fs[3])
+
+            # Softmax matching with mask exclusion
+            yi = yi * mm
+            yi = F.softmax(yi * scale, dim=1)
+            yi = yi * mm
+
+            offset = torch.argmax(yi, dim=1, keepdim=True)
+            if int_bs != int_fs:
+                times = float(int_fs[2] * int_fs[3]) / float(int_bs[2] * int_bs[3])
+                offset = ((offset + 1).float() * times - 1).to(torch.int64)
+            offset = torch.cat([offset // int_fs[3], offset % int_fs[3]], dim=1)
+
+            # Reconstruct using original-scale patches
+            wi_center = raw_wi[0]
+            yi = F.conv_transpose2d(yi, wi_center, stride=self.rate, padding=1) / 4.
+            y.append(yi)
+            offsets.append(offset)
+
+        y = torch.cat(y, dim=0)
+        y.contiguous().view(raw_int_fs)
+
+        offsets = torch.cat(offsets, dim=0)
+        offsets = offsets.view(int_fs[0], 2, *int_fs[2:])
+
+        return y, offsets
+
+
+# =============================================================================
+# SemanticInpaintGenerator (from src/networks.py)
+# =============================================================================
+
+class BaseNetwork(nn.Module):
+    """Base class with weight initialization for CUHK networks."""
+
+    def __init__(self):
+        super().__init__()
+
+    def init_weights(self, init_type: str = 'normal', gain: float = 0.02):
+        def init_func(m):
+            classname = m.__class__.__name__
+            if hasattr(m, 'weight') and (classname.find('Conv') != -1 or classname.find('Linear') != -1):
+                if init_type == 'normal':
+                    nn.init.normal_(m.weight.data, 0.0, gain)
+                elif init_type == 'xavier':
+                    nn.init.xavier_normal_(m.weight.data, gain=gain)
+                elif init_type == 'kaiming':
+                    nn.init.kaiming_normal_(m.weight.data, a=0, mode='fan_in')
+                elif init_type == 'orthogonal':
+                    nn.init.orthogonal_(m.weight.data, gain=gain)
+                if hasattr(m, 'bias') and m.bias is not None:
+                    nn.init.constant_(m.bias.data, 0.0)
+            elif classname.find('BatchNorm2d') != -1:
+                nn.init.normal_(m.weight.data, 1.0, gain)
+                nn.init.constant_(m.bias.data, 0.0)
+
+        self.apply(init_func)
+
+
+class SemanticInpaintGenerator(BaseNetwork):
+    """Dual-head encoder-decoder for structural line and screentone inpainting.
+
+    Input: 7 channels (screen_masked[4] + lines_masked[1] + mask[1] + noise[1])
+    Output: (screentone_map[4], structural_lines[1])
+
+    Architecture: Encoder (4 stages) → ResNet middle → Two parallel decoders
+      - Screentone decoder (bilinear upsampling)
+      - Line decoder (transposed convolutions with skip connections)
+    """
+
+    def __init__(self, in_channels: int = 3, out_channels: int = 4,
+                 residual_blocks: int = 6, init_weights: bool = True):
+        super().__init__()
+
+        self.encoder1 = nn.Sequential(
+            nn.ReflectionPad2d(3),
+            _spectral_norm(nn.Conv2d(in_channels, 64, kernel_size=7, padding=0)),
+            LayerNormWrapper(64),
+            nn.ReLU(True)
+        )
+        self.encoder2 = nn.Sequential(
+            _spectral_norm(nn.Conv2d(64, 128, kernel_size=4, stride=2, padding=1)),
+            LayerNormWrapper(128),
+            nn.ReLU(True)
+        )
+        self.encoder3 = nn.Sequential(
+            _spectral_norm(nn.Conv2d(128, 256, kernel_size=4, stride=2, padding=1)),
+            LayerNormWrapper(256),
+            nn.ReLU(True)
+        )
+        self.encoder4 = nn.Sequential(
+            _spectral_norm(nn.Conv2d(256, 256, kernel_size=4, stride=2, padding=1)),
+            LayerNormWrapper(256),
+            nn.ReLU(True)
+        )
+
+        blocks = []
+        for _ in range(residual_blocks):
+            blocks.append(CUHKResnetBlock(256, 2, use_instance=True))
+        self.middle = nn.Sequential(*blocks)
+
+        # Screentone decoder (bilinear upsampling path)
+        self.decoder_scr4 = nn.Sequential(
+            nn.UpsamplingBilinear2d(scale_factor=2),
+            _spectral_norm(nn.Conv2d(256, 256, kernel_size=3, stride=1, padding=1)),
+            nn.ReLU(True)
+        )
+        self.decoder_scr3 = nn.Sequential(
+            nn.UpsamplingBilinear2d(scale_factor=2),
+            _spectral_norm(nn.Conv2d(256, 128, kernel_size=3, stride=1, padding=1)),
+            nn.ReLU(True)
+        )
+        self.decoder_scr2 = nn.Sequential(
+            nn.UpsamplingBilinear2d(scale_factor=2),
+            _spectral_norm(nn.Conv2d(128, 64, kernel_size=3, stride=1, padding=1)),
+            nn.ReLU(True)
+        )
+        self.decoder_scr1 = nn.Sequential(
+            nn.ReflectionPad2d(3),
+            nn.Conv2d(64, out_channels, kernel_size=7, padding=0),
+        )
+
+        # Line decoder (transposed convolution with skip connections)
+        self.decoder_l4 = nn.Sequential(
+            _spectral_norm(nn.ConvTranspose2d(256, 256, kernel_size=4, stride=2, padding=1)),
+            LayerNormWrapper(256),
+            nn.ReLU(True)
+        )
+        self.decoder_l3 = nn.Sequential(
+            _spectral_norm(nn.ConvTranspose2d(256, 128, kernel_size=4, stride=2, padding=1)),
+            LayerNormWrapper(128),
+            nn.ReLU(True)
+        )
+        self.decoder_l2 = nn.Sequential(
+            _spectral_norm(nn.ConvTranspose2d(128, 64, kernel_size=4, stride=2, padding=1)),
+            LayerNormWrapper(64),
+            nn.ReLU(True)
+        )
+        self.decoder_l1 = nn.Sequential(
+            nn.ReflectionPad2d(3),
+            nn.Conv2d(64, 1, kernel_size=7, padding=0),
+        )
+
+        if init_weights:
+            self.init_weights()
+
+    def forward(self, xin: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass.
+
+        Args:
+            xin: [B, in_channels, H, W]
+
+        Returns:
+            (screentone_map [B, 4, H, W], structural_lines [B, 1, H, W])
+        """
+        x1 = self.encoder1(xin)
+        x2 = self.encoder2(x1)
+        x3 = self.encoder3(x2)
+        x4 = self.encoder4(x3)
+        x = self.middle(x4)
+
+        # Screentone decoder
+        scr = self.decoder_scr4(x)
+        scr = self.decoder_scr3(scr)
+        scr = self.decoder_scr2(scr)
+        scr = self.decoder_scr1(scr)
+        scr = torch.clamp(scr, -1., 1.)
+
+        # Line decoder with skip connections
+        line = self.decoder_l4(x + x4)
+        line = self.decoder_l3(line + x3)
+        line = self.decoder_l2(line + x2)
+        line = self.decoder_l1(line + x1)
+        line = torch.clamp(line, -1., 1.)
+
+        return scr, line
+
+
+# =============================================================================
+# MangaInpaintGenerator (from src/networks.py)
+# =============================================================================
+
+class MangaInpaintGenerator(BaseNetwork):
+    """Two-branch appearance synthesis generator with contextual attention.
+
+    Branch 1: Dilated convolutions (hallucination)
+    Branch 2: Contextual attention (texture borrowing)
+    Merged via concatenation + decoder
+
+    Input: (masked_image[1] + hints[5] + ones[1] + mask[1]) = 8 channels
+    Output: grayscale inpainted region [1 channel]
+    """
+
+    def __init__(self, input_dim: int = 6, cnum: int = 32, output_dim: int = 1,
+                 init_weights: bool = True):
+        super().__init__()
+
+        # Dilated convolution branch
+        self.conv1 = gen_conv(input_dim + 2, cnum, 5, 1, 2)
+        self.conv2_downsample = gen_conv(cnum, cnum, 3, 2, 1)
+        self.conv3 = gen_conv(cnum, cnum * 2, 3, 1, 1)
+        self.conv4_downsample = gen_conv(cnum * 2, cnum * 2, 3, 2, 1)
+        self.conv5 = gen_conv(cnum * 2, cnum * 4, 3, 1, 1)
+        self.conv6_downsample = gen_conv(cnum * 4, cnum * 4, 3, 1, 1)
+
+        self.conv7_atrous = gen_conv(cnum * 4, cnum * 4, 3, 1, 2, rate=2)
+        self.conv8_atrous = gen_conv(cnum * 4, cnum * 4, 3, 1, 4, rate=4)
+        self.conv9_atrous = gen_conv(cnum * 4, cnum * 4, 3, 1, 8, rate=8)
+        self.conv10_atrous = gen_conv(cnum * 4, cnum * 4, 3, 1, 16, rate=16)
+
+        # Contextual attention branch
+        self.pmconv1 = gen_conv(input_dim + 2, cnum, 5, 1, 2)
+        self.pmconv2_downsample = gen_conv(cnum, cnum, 3, 2, 1)
+        self.pmconv3 = gen_conv(cnum, cnum * 2, 3, 1, 1)
+        self.pmconv4_downsample = gen_conv(cnum * 2, cnum * 4, 3, 2, 1)
+        self.pmconv5 = gen_conv(cnum * 4, cnum * 4, 3, 1, 1)
+        self.pmconv6 = gen_conv(cnum * 4, cnum * 4, 3, 1, 1, activation='relu')
+        self.contextul_attention = ContextualAttention(
+            ksize=3, stride=1, rate=2, fuse_k=3, softmax_scale=10, fuse=True
+        )
+        self.pmconv9 = gen_conv(cnum * 4, cnum * 4, 3, 1, 1)
+        self.pmconv10 = gen_conv(cnum * 4, cnum * 4, 3, 1, 1)
+
+        # Merge + decoder
+        self.allconv11 = gen_conv(cnum * 8, cnum * 4, 3, 1, 1)
+        self.allconv12 = gen_conv(cnum * 4, cnum * 4, 3, 1, 1)
+        self.allconv13 = gen_deconv(cnum * 4, cnum * 2, 3, 2, 1)
+        self.allconv14 = gen_conv(cnum * 2, cnum * 2, 3, 1, 1)
+        self.allconv15 = gen_deconv(cnum * 2, cnum, 3, 2, 1)
+        self.allconv16 = gen_conv(cnum, cnum // 2, 3, 1, 1)
+        self.allconv17 = gen_conv(cnum // 2, output_dim, 5, 1, 2, activation='none')
+
+        if init_weights:
+            self.init_weights()
+
+    def forward(self, xin: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            xin: [B, input_dim, H, W] (masked_image + hints)
+            mask: [B, 1, H, W]
+
+        Returns:
+            [B, 1, H, W] inpainted grayscale output
+        """
+        ones = torch.ones_like(mask)
+        xnow = torch.cat([xin, ones, mask], dim=1)
+
+        # Dilated conv branch
+        x = self.conv1(xnow)
+        x = self.conv2_downsample(x)
+        x = self.conv3(x)
+        x = self.conv4_downsample(x)
+        x = self.conv5(x)
+        x = self.conv6_downsample(x)
+        x = self.conv7_atrous(x)
+        x = self.conv8_atrous(x)
+        x = self.conv9_atrous(x)
+        x = self.conv10_atrous(x)
+        x_hallu = x
+
+        # Contextual attention branch
+        x = self.pmconv1(xnow)
+        x = self.pmconv2_downsample(x)
+        x = self.pmconv3(x)
+        x = self.pmconv4_downsample(x)
+        x = self.pmconv5(x)
+        x = self.pmconv6(x)
+        x, _offset_flow = self.contextul_attention(x, x, mask)
+        x = self.pmconv9(x)
+        x = self.pmconv10(x)
+
+        # Merge branches
+        x = torch.cat([x_hallu, x], dim=1)
+        x = self.allconv11(x)
+        x = self.allconv12(x)
+        x = self.allconv13(x)
+        x = self.allconv14(x)
+        x = self.allconv15(x)
+        x = self.allconv16(x)
+        x = self.allconv17(x)
+
+        return torch.clamp(x, -1., 1.)
+
+
+# =============================================================================
+# ScreenVAE Encoder Architecture (from src/svae.py)
+# =============================================================================
+
+class SVAELayerNormWrapper(nn.Module):
+    """Device-agnostic LayerNorm for ScreenVAE components.
+
+    The original ScreenVAE uses a separate LayerNormWarpper (with typo)
+    that also hardcodes .cuda(). Fixed here.
+    """
+
+    def __init__(self, num_features: int):
+        super().__init__()
+        self.num_features = int(num_features)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shape = [self.num_features, x.size(2), x.size(3)]
+        return F.layer_norm(x, shape)
+
+
+def _get_svae_norm_layer(norm_type: str = 'instance'):
+    """Return a normalization layer factory for ScreenVAE components."""
+    if norm_type == 'batch':
+        return functools.partial(nn.BatchNorm2d, affine=True, track_running_stats=True)
+    elif norm_type == 'instance':
+        return functools.partial(nn.InstanceNorm2d, affine=False, track_running_stats=False)
+    elif norm_type == 'layer':
+        return functools.partial(SVAELayerNormWrapper)
+    elif norm_type == 'none':
+        return None
+    else:
+        raise NotImplementedError(f'normalization layer [{norm_type}] is not found')
+
+
+def _get_non_linearity(layer_type: str = 'relu'):
+    """Return an activation layer factory."""
+    if layer_type == 'relu':
+        return functools.partial(nn.ReLU, inplace=True)
+    elif layer_type == 'lrelu':
+        return functools.partial(nn.LeakyReLU, negative_slope=0.2, inplace=True)
+    elif layer_type == 'elu':
+        return functools.partial(nn.ELU, inplace=True)
+    elif layer_type == 'selu':
+        return functools.partial(nn.SELU, inplace=True)
+    elif layer_type == 'prelu':
+        return functools.partial(nn.PReLU)
+    else:
+        raise NotImplementedError(f'nonlinearity [{layer_type}] is not found')
+
+
+class SVAEResnetBlock(nn.Module):
+    """Residual block for ScreenVAE's ResnetGenerator encoder."""
+
+    def __init__(self, dim: int, padding_type: str, norm_layer, use_dropout: bool, use_bias: bool):
+        super().__init__()
+        self.conv_block = self._build(dim, padding_type, norm_layer, use_dropout, use_bias)
+
+    def _build(self, dim, padding_type, norm_layer, use_dropout, use_bias):
+        conv_block = []
+        p = 0
+        if padding_type == 'reflect':
+            conv_block += [nn.ReflectionPad2d(1)]
+        elif padding_type == 'replicate':
+            conv_block += [nn.ReplicationPad2d(1)]
+        elif padding_type == 'zero':
+            p = 1
+        else:
+            raise NotImplementedError(f'padding [{padding_type}] is not implemented')
+
+        conv_block += [nn.Conv2d(dim, dim, kernel_size=3, padding=p, bias=use_bias)]
+        if norm_layer is not None:
+            conv_block += [norm_layer(dim)]
+        conv_block += [nn.ReLU(True)]
+
+        p = 0
+        if padding_type == 'reflect':
+            conv_block += [nn.ReflectionPad2d(1)]
+        elif padding_type == 'replicate':
+            conv_block += [nn.ReplicationPad2d(1)]
+        elif padding_type == 'zero':
+            p = 1
+
+        conv_block += [nn.Conv2d(dim, dim, kernel_size=3, padding=p, bias=use_bias)]
+        if norm_layer is not None:
+            conv_block += [norm_layer(dim)]
+
+        return nn.Sequential(*conv_block)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.conv_block(x)
+
+
+class ScreenVAEEncoder(nn.Module):
+    """ResNet-6blocks encoder for ScreenVAE.
+
+    Encodes (grayscale_manga[1] + structural_lines[1]) → screentone_representation[8]
+    where output is split into (mean[4], logvar[4]).
+
+    Architecture: ReflPad → Conv7x7 → 3x Conv↓ → 6x ResBlock → 3x Upsample → Conv7x7
+    """
+
+    def __init__(self, input_nc: int = 2, output_nc: int = 8, ngf: int = 24,
+                 norm_type: str = 'layer', n_downsampling: int = 3, n_blocks: int = 6,
+                 padding_type: str = 'replicate'):
+        super().__init__()
+
+        norm_layer = _get_svae_norm_layer(norm_type)
+        use_bias = True
+        if norm_layer is not None:
+            if type(norm_layer) == functools.partial:
+                use_bias = norm_layer.func != nn.BatchNorm2d
+            else:
+                use_bias = norm_layer != nn.BatchNorm2d
+
+        # Initial conv
+        model = [
+            nn.ReplicationPad2d(3),
+            nn.Conv2d(input_nc, ngf, kernel_size=7, padding=0, bias=use_bias)
+        ]
+        if norm_layer is not None:
+            model += [norm_layer(ngf)]
+        model += [nn.ReLU(True)]
+
+        # Downsampling
+        for i in range(n_downsampling):
+            mult = 2 ** i
+            model += [
+                nn.ReplicationPad2d(1),
+                nn.Conv2d(ngf * mult, ngf * mult * 2, kernel_size=3,
+                          stride=2, padding=0, bias=use_bias)
+            ]
+            if norm_layer is not None:
+                model += [norm_layer(ngf * mult * 2)]
+            model += [nn.ReLU(True)]
+
+        # Residual blocks
+        mult = 2 ** n_downsampling
+        for _ in range(n_blocks):
+            model += [SVAEResnetBlock(
+                ngf * mult, padding_type=padding_type,
+                norm_layer=norm_layer, use_dropout=True, use_bias=use_bias
+            )]
+
+        # Upsampling
+        for i in range(n_downsampling):
+            mult = 2 ** (n_downsampling - i)
+            # Bilinear upsample + conv
+            model += [
+                nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True),
+                nn.Conv2d(ngf * mult, int(ngf * mult / 2), kernel_size=1, stride=1, padding=0)
+            ]
+            if norm_layer is not None:
+                model += [norm_layer(int(ngf * mult / 2))]
+            model += [nn.ReLU(True)]
+            model += [
+                nn.ReplicationPad2d(1),
+                nn.Conv2d(int(ngf * mult / 2), int(ngf * mult / 2), kernel_size=3, padding=0)
+            ]
+            if norm_layer is not None:
+                model += [norm_layer(ngf * mult / 2)]
+            model += [nn.ReLU(True)]
+
+        # Final output conv
+        model += [nn.ReplicationPad2d(3)]
+        model += [nn.Conv2d(ngf, output_nc, kernel_size=7, padding=0)]
+
+        self.model = nn.Sequential(*model)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)
+
+
+# =============================================================================
+# Builder Functions
+# =============================================================================
+
+def build_screenvae_encoder(device: str | torch.device = 'cpu') -> ScreenVAEEncoder:
+    """Build the ScreenVAE encoder network.
+
+    Input: 2ch (grayscale + lines) → Output: 8ch (4ch screentone mean + 4ch logvar)
+    """
+    encoder = ScreenVAEEncoder(
+        input_nc=2, output_nc=8, ngf=24,
+        norm_type='layer', n_downsampling=3, n_blocks=6,
+        padding_type='replicate'
+    )
+    encoder.to(device)
+    encoder.eval()
+    return encoder
+
+
+def build_semantic_generator(device: str | torch.device = 'cpu') -> SemanticInpaintGenerator:
+    """Build the SemanticInpaintGenerator.
+
+    Input: 7ch (screen_masked[4] + lines_masked[1] + mask[1] + noise[1])
+    Output: (screentone[4], lines[1])
+    """
+    gen = SemanticInpaintGenerator(in_channels=7, init_weights=False)
+    gen.to(device)
+    gen.eval()
+    return gen
+
+
+def build_manga_generator(device: str | torch.device = 'cpu') -> MangaInpaintGenerator:
+    """Build the MangaInpaintGenerator.
+
+    Input: 6ch (masked_image[1] + hints[5]) + 2ch (ones + mask) appended in forward
+    Output: 1ch grayscale
+    """
+    gen = MangaInpaintGenerator(input_dim=6, cnum=32, init_weights=False)
+    gen.to(device)
+    gen.eval()
+    return gen

--- a/modules/inpainting/mi_gan.py
+++ b/modules/inpainting/mi_gan.py
@@ -22,26 +22,28 @@ logger = logging.getLogger(__name__)
 
 class MIGAN(TorchAutocastMixin, InpaintModel):
     name = "migan"
+    preferred_backend = "torch"  # ONNX download URL is not available
     min_size = 512
     pad_mod = 512
     pad_to_square = True
     is_erase_model = True
-    use_pipeline_for_onnx = False
+    use_pipeline_for_onnx = True
 
     def init_model(self, device, **kwargs):
-        self.backend = kwargs.get("backend")
-        if self.backend == "onnx":
-            model_id = ModelID.MIGAN_PIPELINE_ONNX if self.use_pipeline_for_onnx else ModelID.MIGAN_ONNX
-            ModelDownloader.get(model_id)
-            onnx_path = ModelDownloader.primary_path(model_id)
-            providers = get_providers(device)
-            self.session = make_session(onnx_path, providers=providers)
-        else:
+        # MI-GAN requires PyTorch — no working ONNX model is available
+        try:
             import torch
-            ModelDownloader.get(ModelID.MIGAN_JIT)
-            local_path = ModelDownloader.primary_path(ModelID.MIGAN_JIT)
-            self.model = load_jit_model(local_path, device)
-            self.setup_torch_autocast(torch, device)
+        except ImportError:
+            raise RuntimeError(
+                "MI-GAN requires PyTorch. Please install it with:\n"
+                "  pip install torch\n"
+                "Or select a different inpainter (LaMa or AOT)."
+            )
+        self.backend = "torch"
+        ModelDownloader.get(ModelID.MIGAN_JIT)
+        local_path = ModelDownloader.primary_path(ModelID.MIGAN_JIT)
+        self.model = load_jit_model(local_path, device)
+        self.setup_torch_autocast(torch, device)
 
     @staticmethod
     def is_downloaded() -> bool:
@@ -53,8 +55,15 @@ class MIGAN(TorchAutocastMixin, InpaintModel):
         masks: [H, W]
         return: BGR IMAGE
         """
-        import torch  # noqa
-        with torch.no_grad():
+        backend = getattr(self, 'backend', 'torch')
+        if backend != 'onnx':
+            import torch  # noqa
+            ctx = torch.no_grad()
+        else:
+            from contextlib import nullcontext
+            ctx = nullcontext()
+
+        with ctx:
             if image.shape[0] == 512 and image.shape[1] == 512:
                 return self._pad_forward(image, mask, config)
 

--- a/modules/ocr/factory.py
+++ b/modules/ocr/factory.py
@@ -157,6 +157,7 @@ class OCRFactory:
             'Google Cloud Vision': cls._create_google_ocr,
             'GPT-4.1-mini': lambda s: cls._create_gpt_ocr(s, ocr_model),
             'Gemini-2.0-Flash': lambda s: cls._create_gemini_ocr(s, ocr_model),
+            'Manga OCR 2025': lambda s: cls._create_manga_ocr_2025(s, effective_backend),
         }
         
         # Language-specific factory functions (for Default model)
@@ -254,4 +255,19 @@ class OCRFactory:
     def _create_gemini_ocr(settings, model) -> OCREngine:
         engine = GeminiOCR()
         engine.initialize(settings, model)
+        return engine
+
+    @staticmethod
+    def _create_manga_ocr_2025(settings, backend: str = 'onnx') -> OCREngine:
+        device = resolve_device(settings.is_gpu_enabled(), backend)
+
+        if backend.lower() == 'torch' and torch_available():
+            from .manga_ocr_2025.engine import MangaOCR2025Engine
+            engine = MangaOCR2025Engine()
+            engine.initialize(device=device)
+        else:
+            from .manga_ocr_2025.onnx_engine import MangaOCR2025EngineONNX
+            engine = MangaOCR2025EngineONNX()
+            engine.initialize(device=device)
+
         return engine

--- a/modules/ocr/manga_ocr_2025/__init__.py
+++ b/modules/ocr/manga_ocr_2025/__init__.py
@@ -1,0 +1,1 @@
+# Manga OCR 2025 package

--- a/modules/ocr/manga_ocr_2025/engine.py
+++ b/modules/ocr/manga_ocr_2025/engine.py
@@ -1,0 +1,98 @@
+import os
+import numpy as np
+import re
+import jaconv
+import logging
+
+from modules.ocr.base import OCREngine
+from modules.utils.textblock import TextBlock, adjust_text_line_coordinates
+from modules.utils.download import ModelDownloader, ModelID, models_base_dir
+from modules.utils.torch_autocast import TorchAutocastMixin
+
+logger = logging.getLogger(__name__)
+
+
+class MangaOCR2025Engine(OCREngine):
+    """OCR engine using the upgraded manga-ocr-base-2025 model for Japanese text.
+
+    This is the 2025 fine-tuned version of kha-white/manga-ocr, offering
+    improved accuracy on modern manga fonts and layouts.  Uses TrOCRProcessor
+    instead of ViTImageProcessor from the original model.
+    """
+
+    def __init__(self):
+        self.model = None
+        self.device = 'cpu'
+        self.expansion_percentage = 5
+
+    def initialize(self, device: str = 'cpu', expansion_percentage: int = 5) -> None:
+        self.device = device
+        self.expansion_percentage = expansion_percentage
+        if self.model is None:
+            ModelDownloader.get(ModelID.MANGA_OCR_2025)
+            model_path = os.path.join(models_base_dir, 'ocr', 'manga-ocr-base-2025')
+            self.model = MangaOcr2025(pretrained_model_name_or_path=model_path, device=device)
+
+    def process_image(self, img: np.ndarray, blk_list: list[TextBlock]) -> list[TextBlock]:
+        for blk in blk_list:
+            if blk.bubble_xyxy is not None:
+                x1, y1, x2, y2 = blk.bubble_xyxy
+            else:
+                x1, y1, x2, y2 = adjust_text_line_coordinates(
+                    blk.xyxy,
+                    self.expansion_percentage,
+                    self.expansion_percentage,
+                    img
+                )
+
+            if x1 < x2 and y1 < y2 and x1 >= 0 and y1 >= 0 and x2 <= img.shape[1] and y2 <= img.shape[0]:
+                cropped_img = img[y1:y2, x1:x2]
+                blk.text = self.model(cropped_img)
+            else:
+                print('Invalid textbbox to target img')
+                blk.text = ""
+
+        return blk_list
+
+
+class MangaOcr2025(TorchAutocastMixin):
+    """Wrapper around the manga-ocr-base-2025 VisionEncoderDecoderModel.
+
+    Uses TrOCRProcessor (replacing the older ViTImageProcessor) for
+    preprocessing, and VisionEncoderDecoderModel for generation.
+    """
+
+    def __init__(self, pretrained_model_name_or_path: str, device: str = 'cpu'):
+        import torch
+        from transformers import TrOCRProcessor, VisionEncoderDecoderModel
+
+        self.processor = TrOCRProcessor.from_pretrained(pretrained_model_name_or_path)
+        self.model = VisionEncoderDecoderModel.from_pretrained(pretrained_model_name_or_path)
+        self.setup_torch_autocast(torch, device)
+        self.to(device)
+
+    def to(self, device):
+        self.model.to(device)
+
+    def __call__(self, img: np.ndarray) -> str:
+        import torch
+
+        x = self.processor(img, return_tensors="pt").pixel_values.squeeze()
+        with torch.inference_mode():
+            x = self.run_with_torch_autocast(
+                torch_module=torch,
+                fn=lambda: self.model.generate(x[None].to(self.model.device))[0].cpu(),
+                logger=logger,
+                engine_name=self.__class__.__name__,
+            )
+        x = self.processor.batch_decode([x], skip_special_tokens=True)[0]
+        x = post_process(x)
+        return x
+
+
+def post_process(text: str) -> str:
+    text = ''.join(text.split())
+    text = text.replace('…', '...')
+    text = re.sub('[・.]{2,}', lambda x: (x.end() - x.start()) * '.', text)
+    text = jaconv.h2z(text, ascii=True, digit=True)
+    return text

--- a/modules/ocr/manga_ocr_2025/onnx_engine.py
+++ b/modules/ocr/manga_ocr_2025/onnx_engine.py
@@ -1,0 +1,183 @@
+import os
+import re
+import jaconv
+import numpy as np
+from PIL import Image
+from typing import Any
+from modules.utils.device import get_providers
+from modules.utils.onnx import make_session
+
+from modules.ocr.base import OCREngine
+from modules.utils.textblock import TextBlock, adjust_text_line_coordinates
+from modules.utils.download import ModelDownloader, ModelID
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MangaOCR2025EngineONNX(OCREngine):
+    """OCR engine using ONNX-exported manga-ocr-2025 models.
+
+    Based on l0wgear/manga-ocr-2025-onnx — the ONNX conversion of the
+    jzhang533/manga-ocr-base-2025 model.  Uses the same encoder/decoder
+    loop architecture as the original MangaOCRONNX but with the 2025
+    weights and vocabulary.
+    """
+
+    def __init__(self):
+        self.model = None
+        self.device = 'cpu'
+        self.expansion_percentage = 5
+
+    def initialize(self, device: str = 'cpu', expansion_percentage: int = 5) -> None:
+        self.device = device
+        self.expansion_percentage = expansion_percentage
+
+        if self.model is None:
+            ModelDownloader.get(ModelID.MANGA_OCR_2025_ONNX)
+            self.model = MangaOCR2025ONNX(device=device)
+
+    def process_image(self, img: np.ndarray, blk_list: list[TextBlock]) -> list[TextBlock]:
+        for blk in blk_list:
+            if blk.bubble_xyxy is not None:
+                x1, y1, x2, y2 = blk.bubble_xyxy
+            else:
+                x1, y1, x2, y2 = adjust_text_line_coordinates(
+                    blk.xyxy,
+                    self.expansion_percentage,
+                    self.expansion_percentage,
+                    img,
+                )
+
+            if x1 < x2 and y1 < y2 and x1 >= 0 and y1 >= 0 and x2 <= img.shape[1] and y2 <= img.shape[0]:
+                cropped_img = img[y1:y2, x1:x2]
+                try:
+                    blk.text = self.model(cropped_img)
+                except Exception:
+                    blk.text = ""
+            else:
+                blk.text = ""
+
+        return blk_list
+
+
+class MangaOCR2025ONNX:
+    """Wrapper around ONNX encoder/decoder sessions for Manga OCR 2025.
+
+    Mirrors the architecture of MangaOCRONNX but loads the 2025 model
+    weights which offer improved accuracy.  Input/output names are
+    discovered dynamically from the ONNX graphs.
+    """
+
+    def __init__(self, device: str = 'cpu'):
+        self.device = device
+
+        encoder_path = ModelDownloader.get_file_path(ModelID.MANGA_OCR_2025_ONNX, "encoder_model.onnx")
+        decoder_path = ModelDownloader.get_file_path(ModelID.MANGA_OCR_2025_ONNX, "decoder_model.onnx")
+        vocab_path = ModelDownloader.get_file_path(ModelID.MANGA_OCR_2025_ONNX, "vocab.txt")
+
+        providers = get_providers(self.device)
+        self.encoder = make_session(encoder_path, providers=providers)
+        self.decoder = make_session(decoder_path, providers=providers)
+
+        self.vocab = self._load_vocab(vocab_path)
+
+        # Discover input/output names from ONNX graphs
+        self.encoder_image_input = self._find_input_name(
+            self.encoder, candidates=('image', 'pixel_values', 'input')
+        )
+        self.encoder_output_name = self.encoder.get_outputs()[0].name
+
+        self.decoder_token_input = self._find_input_name(
+            self.decoder, candidates=('token_ids', 'input_ids', 'input')
+        )
+        self.decoder_encoder_input = self._find_input_name(
+            self.decoder,
+            candidates=('encoder_hidden_states', 'encoder_outputs', 'encoder_last_hidden_state'),
+        )
+
+    def _find_input_name(self, session: Any, candidates=('input',)) -> str:
+        names = [inp.name for inp in session.get_inputs()]
+        for cand in candidates:
+            for n in names:
+                if cand in n:
+                    return n
+        return names[0]
+
+    def _load_vocab(self, vocab_file: str) -> list:
+        with open(vocab_file, 'r', encoding='utf-8') as f:
+            lines = f.read().splitlines()
+        return lines
+
+    def __call__(self, img: np.ndarray) -> str:
+        img_in = self._preprocess(img)
+        token_ids = self._generate(img_in)
+        text = self._decode(token_ids)
+        text = self._postprocess(text)
+        return text
+
+    def _preprocess(self, img: np.ndarray) -> np.ndarray:
+        if img is None or img.size == 0:
+            raise ValueError('Empty image passed to MangaOCR2025ONNX')
+
+        if isinstance(img, np.ndarray):
+            img = Image.fromarray(img)
+        elif not isinstance(img, Image.Image):
+            img = Image.fromarray(np.array(img))
+
+        # Convert to grayscale and back to RGB to match training preprocessing
+        img = img.convert('L').convert('RGB')
+        img = img.resize((224, 224), resample=Image.BILINEAR)
+
+        arr = np.array(img, dtype=np.float32)
+        arr /= 255.0
+        arr = (arr - 0.5) / 0.5
+        # (H, W, C) → (C, H, W)
+        arr = arr.transpose((2, 0, 1)).astype(np.float32)
+        # Add batch dimension
+        arr = arr[None]
+
+        return arr
+
+    def _generate(self, image: np.ndarray) -> list:
+        # Run encoder once
+        encoder_feed = {self.encoder_image_input: image}
+        encoder_outs = self.encoder.run(None, encoder_feed)
+        encoder_hidden = encoder_outs[0]
+
+        # Start with BOS token (id=2)
+        token_ids = [2]
+
+        for _ in range(300):
+            decoder_feed = {
+                self.decoder_token_input: np.array([token_ids], dtype=np.int64),
+                self.decoder_encoder_input: encoder_hidden,
+            }
+
+            outs = self.decoder.run(None, decoder_feed)
+            logits = outs[0]
+            next_token = int(np.argmax(logits[0, -1, :]))
+            token_ids.append(next_token)
+
+            # EOS token (id=3)
+            if next_token == 3:
+                break
+
+        return token_ids
+
+    def _decode(self, token_ids: list) -> str:
+        text = ''
+        for tid in token_ids:
+            if tid < 5:
+                continue
+            if tid < len(self.vocab):
+                text += self.vocab[tid]
+        return text
+
+    def _postprocess(self, text: str) -> str:
+        text = ''.join(text.split())
+        text = text.replace('…', '...')
+        text = re.sub('[・.]{2,}', lambda x: (x.end() - x.start()) * '.', text)
+        text = jaconv.h2z(text, ascii=True, digit=True)
+        return text

--- a/modules/utils/device.py
+++ b/modules/utils/device.py
@@ -134,12 +134,43 @@ def tensors_to_device(data: Any, device: str) -> Any:
         return type(data)(seq) if isinstance(data, tuple) else seq
     return data
 
+def _is_tensorrt_usable() -> bool:
+    """Check if TensorRT native libraries are actually loadable.
+
+    ONNX Runtime may report TensorrtExecutionProvider as "available" even
+    when the required nvinfer DLLs are not installed, which causes noisy
+    error messages on every session creation. This function probes for the
+    actual library to prevent that.
+    """
+    import ctypes
+    import sys
+
+    if sys.platform == 'win32':
+        # Try loading the TensorRT inference library on Windows
+        for dll_name in ('nvinfer_10.dll', 'nvinfer.dll'):
+            try:
+                ctypes.WinDLL(dll_name)
+                return True
+            except OSError:
+                continue
+        return False
+    else:
+        # On Linux, try loading the shared object
+        for so_name in ('libnvinfer.so.10', 'libnvinfer.so'):
+            try:
+                ctypes.CDLL(so_name)
+                return True
+            except OSError:
+                continue
+        return False
+
 def get_providers(device: Optional[str] = None) -> list[Any]:
     """Return a providers list for ONNXRuntime (optionally with provider options).
 
     Rules:
     - If device is the string 'cpu' (case-insensitive) -> return ['CPUExecutionProvider']
     - Otherwise return available providers with options for certain GPU providers
+    - Providers whose native libraries are missing are silently skipped
     - If no providers are available, fall back to ['CPUExecutionProvider']
     """
     try:
@@ -153,7 +184,13 @@ def get_providers(device: Optional[str] = None) -> list[Any]:
     if not available:
         return ['CPUExecutionProvider']
 
-    
+    # Filter out TensorRT if its native libraries are not actually installed.
+    # ort.get_available_providers() may list TensorRT even when nvinfer DLLs
+    # are missing, causing noisy error messages on every session creation.
+    if 'TensorrtExecutionProvider' in available:
+        if not _is_tensorrt_usable():
+            available = [p for p in available if p != 'TensorrtExecutionProvider']
+
     # Use user data directory for cache
     base_models_dir = os.path.join(get_user_data_dir(), "models")
     

--- a/modules/utils/download.py
+++ b/modules/utils/download.py
@@ -58,6 +58,7 @@ class ModelID(Enum):
     AOT_ONNX = "aot-onnx"
     AOT_TORCH = "aot-torch"
     LAMA_JIT = "anime-manga-big-lama"
+    LAMA_LARGE_CKPT = "lama-large-512px"
     MIGAN_PIPELINE_ONNX = "migan-pipeline-v2"
     MIGAN_ONNX = "migan-onnx"
     MIGAN_JIT = "migan-traced"
@@ -91,6 +92,18 @@ class ModelID(Enum):
     # Font Detection
     FONT_DETECTOR_ONNX = "font-detector-onnx"
     FONT_DETECTOR_TORCH = "font-detector-torch"
+
+    # YOLOv8 Comic Detector
+    YOLOV8_COMIC_ONNX = "yolov8-comic-onnx"
+
+    # Manga OCR 2025
+    MANGA_OCR_2025 = "manga-ocr-base-2025"
+    MANGA_OCR_2025_ONNX = "manga-ocr-2025-onnx"
+
+    # CUHK MangaInpainting (SIGGRAPH 2021)
+    MANGA_INPAINTING_SEMANTIC = "manga-inpainting-semantic"
+    MANGA_INPAINTING_GENERATOR = "manga-inpainting-generator"
+    MANGA_INPAINTING_SCREENVAE_ENC = "manga-inpainting-screenvae-enc"
 
 
 @dataclass(frozen=True)
@@ -426,6 +439,15 @@ def _register_defaults():
         save_dir=os.path.join(models_base_dir, 'inpainting')
     ))
 
+    # Inpainting: LaMa Large 512px (dreMaz/AnimeMangaInpainting fine-tuned Big LaMa)
+    ModelDownloader.register(ModelSpec(
+        id=ModelID.LAMA_LARGE_CKPT,
+        url='https://huggingface.co/dreMaz/AnimeMangaInpainting/resolve/main/',
+        files=['lama_large_512px.ckpt'],
+        sha256=[None],  # No official checksum published
+        save_dir=os.path.join(models_base_dir, 'inpainting')
+    ))
+
     # Inpainting: MIGAN traced JIT (TorchScript)
     ModelDownloader.register(ModelSpec(
         id=ModelID.MIGAN_JIT,
@@ -629,6 +651,74 @@ def _register_defaults():
         sha256=['9053615071c31978a3988143c9a3bdec8da53e269a8f84b5908d6f15747a1a81'],
         save_dir=os.path.join(models_base_dir, 'detection', 'font'),
         save_as={'name%3D4x-epoch%3D84-step%3D1649340.ckpt': 'font-detector.ckpt'}
+    ))
+
+    # YOLOv8 Comic Speech Bubble Detector (ONNX)
+    ModelDownloader.register(ModelSpec(
+        id=ModelID.YOLOV8_COMIC_ONNX,
+        url='https://huggingface.co/ogkalu/comic-speech-bubble-detector-yolov8m/resolve/main/',
+        files=['comic-speech-bubble-detector.pt'],
+        sha256=[None],
+        save_dir=os.path.join(models_base_dir, 'detection'),
+        save_as={'comic-speech-bubble-detector.pt': 'yolov8-comic.pt'}
+    ))
+
+    # Manga OCR 2025 (PyTorch / Safetensors)
+    ModelDownloader.register(ModelSpec(
+        id=ModelID.MANGA_OCR_2025,
+        url='https://huggingface.co/jzhang533/manga-ocr-base-2025/resolve/main/',
+        files=[
+            'model.safetensors', 'config.json', 'preprocessor_config.json',
+            'special_tokens_map.json', 'tokenizer_config.json', 'vocab.txt',
+            'generation_config.json'
+        ],
+        sha256=[None, None, None, None, None, None, None],
+        save_dir=os.path.join(models_base_dir, 'ocr', 'manga-ocr-base-2025')
+    ))
+
+    # Manga OCR 2025 (ONNX)
+    ModelDownloader.register(ModelSpec(
+        id=ModelID.MANGA_OCR_2025_ONNX,
+        url='https://huggingface.co/l0wgear/manga-ocr-2025-onnx/resolve/main/',
+        files=[
+            'encoder_model.onnx', 'decoder_model.onnx', 'vocab.txt',
+            'config.json', 'preprocessor_config.json', 'tokenizer.json',
+            'tokenizer_config.json', 'special_tokens_map.json',
+            'generation_config.json'
+        ],
+        sha256=[None, None, None, None, None, None, None, None, None],
+        save_dir=os.path.join(models_base_dir, 'ocr', 'manga-ocr-2025-onnx')
+    ))
+
+    # -------------------------------------------------------------------------
+    # CUHK MangaInpainting (SIGGRAPH 2021)
+    # Downloads handled internally via gdown (Google Drive); specs registered
+    # here for is_downloaded() checks and path resolution.
+    # -------------------------------------------------------------------------
+    _manga_inp_dir = os.path.join(models_base_dir, 'inpainting', 'manga-inpainting')
+
+    ModelDownloader.register(ModelSpec(
+        id=ModelID.MANGA_INPAINTING_SEMANTIC,
+        url='',  # Downloaded via gdown from Google Drive
+        files=['SemanticInpaintingModel_gen.pth'],
+        sha256=[None],
+        save_dir=_manga_inp_dir,
+    ))
+
+    ModelDownloader.register(ModelSpec(
+        id=ModelID.MANGA_INPAINTING_GENERATOR,
+        url='',  # Downloaded via gdown from Google Drive
+        files=['MangaInpaintingModel_gen.pth'],
+        sha256=[None],
+        save_dir=_manga_inp_dir,
+    ))
+
+    ModelDownloader.register(ModelSpec(
+        id=ModelID.MANGA_INPAINTING_SCREENVAE_ENC,
+        url='',  # Downloaded via gdown from Google Drive
+        files=['latest_net_enc.pth'],
+        sha256=[None],
+        save_dir=_manga_inp_dir,
     ))
 
 _register_defaults()

--- a/modules/utils/pipeline_config.py
+++ b/modules/utils/pipeline_config.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from PySide6.QtCore import QCoreApplication
 from typing import TYPE_CHECKING
 from modules.inpainting.lama import LaMa
+from modules.inpainting.lama_large import LamaLarge
 from modules.inpainting.mi_gan import MIGAN
 from modules.inpainting.aot import AOT
+from modules.inpainting.manga_inpainting import MangaInpainting
 from modules.inpainting.schema import Config
 from app.ui.messages import Messages
 from app.ui.settings.settings_page import SettingsPage
@@ -14,14 +16,21 @@ if TYPE_CHECKING:
 
 inpaint_map = {
     "LaMa": LaMa,
+    "LaMa Large": LamaLarge,
     "MI-GAN": MIGAN,
     "AOT": AOT,
+    "Manga Inpainting": MangaInpainting,
 }
 
 
+
 def get_inpainter_backend(inpainter_key: str) -> str:
+    from modules.utils.device import torch_available
     inpainter_cls = inpaint_map[inpainter_key]
-    return getattr(inpainter_cls, "preferred_backend", "onnx")
+    preferred = getattr(inpainter_cls, "preferred_backend", "onnx")
+    if preferred == "torch" and not torch_available():
+        return "onnx"
+    return preferred
 
 def get_config(settings_page: SettingsPage):
     strategy_settings = settings_page.get_hd_strategy_settings()

--- a/modules/utils/resize_output.py
+++ b/modules/utils/resize_output.py
@@ -1,0 +1,170 @@
+"""Post-processing output resize for HD Strategy.
+
+When the user selects HD Strategy "Resize", the final output image should be
+resized so that its longer side does not exceed the configured resize_limit.
+This is applied *after* all processing (inpainting, text rendering) is complete,
+at save/export time.
+
+The existing "Resize Before Inpaint" logic in modules/inpainting/base.py is
+NOT affected by this module.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+import imkit as imk
+from PIL import Image
+
+if TYPE_CHECKING:
+    from app.ui.settings.settings_page import SettingsPage
+
+logger = logging.getLogger(__name__)
+
+
+def apply_output_resize(
+    image: np.ndarray,
+    settings_page: SettingsPage,
+) -> np.ndarray:
+    """Apply HD Strategy Resize to a final output image (post-processing).
+
+    If the HD Strategy is set to "Resize" and the image's longer side
+    exceeds the configured ``resize_limit``, the image is proportionally
+    downscaled using BICUBIC interpolation.
+
+    Args:
+        image: RGB numpy array ``[H, W, C]``.
+        settings_page: The application's SettingsPage instance used to
+            read the current HD Strategy settings.
+
+    Returns:
+        The (potentially resized) image as an ``np.ndarray``.  If the
+        strategy is not "Resize" or the image is already within the
+        limit, the *original* array reference is returned unchanged.
+    """
+    if image is None:
+        logger.debug("apply_output_resize: image is None, skipping.")
+        return image
+
+    try:
+        strategy_settings = settings_page.get_hd_strategy_settings()
+    except Exception:
+        logger.debug("Could not read HD strategy settings; skipping output resize.", exc_info=True)
+        return image
+
+    strategy = strategy_settings.get("strategy", "")
+
+    # Normalize the (possibly translated) strategy label back to its
+    # canonical English key using the UI's value_mappings dict.  This
+    # makes the comparison bulletproof regardless of the active locale.
+    value_mappings = getattr(settings_page.ui, "value_mappings", {})
+    canonical_strategy = value_mappings.get(strategy, strategy)
+
+    is_resize = canonical_strategy == "Resize" or strategy == "Resize"
+
+    logger.info(
+        "apply_output_resize: strategy=%r, canonical=%r, is_resize=%s",
+        strategy, canonical_strategy, is_resize,
+    )
+
+    if not is_resize:
+        logger.info("apply_output_resize: strategy is not Resize, skipping.")
+        return image
+
+    resize_limit = int(strategy_settings.get("resize_limit", 0))
+    if resize_limit <= 0:
+        logger.warning(
+            "apply_output_resize: resize_limit=%d is invalid, skipping resize.",
+            resize_limit,
+        )
+        return image
+
+    h, w = image.shape[:2]
+    longer_side = max(h, w)
+
+    if longer_side <= resize_limit:
+        logger.info(
+            "apply_output_resize: image (%d, %d) already within limit=%d, no resize needed.",
+            w, h, resize_limit,
+        )
+        return image
+
+    ratio = resize_limit / longer_side
+    new_w = int(w * ratio + 0.5)
+    new_h = int(h * ratio + 0.5)
+
+    logger.info(
+        "apply_output_resize: resizing (%d, %d) -> (%d, %d) [limit=%d, ratio=%.4f]",
+        w, h, new_w, new_h, resize_limit, ratio,
+    )
+
+    resized = imk.resize(image, (new_w, new_h), mode=Image.Resampling.BICUBIC)
+    return resized
+
+
+def apply_width_limit_resize(
+    image: np.ndarray,
+    settings_page: SettingsPage,
+) -> np.ndarray:
+    """Scale the output image so its width matches a configured target value.
+
+    This is **independent** of the HD Strategy Resize feature.  It reads
+    the "Limit Output Width" toggle and target width from the Export
+    settings and resizes the image proportionally (height adapts to
+    maintain the aspect ratio).
+
+    Args:
+        image: RGB numpy array ``[H, W, C]``.
+        settings_page: The application's SettingsPage instance used to
+            read the current Export settings.
+
+    Returns:
+        The (potentially resized) image as an ``np.ndarray``.  If the
+        feature is disabled or the image already matches the target
+        width, the *original* array reference is returned unchanged.
+    """
+    if image is None:
+        return image
+
+    try:
+        export_settings = settings_page.get_export_settings()
+    except Exception:
+        logger.debug(
+            "apply_width_limit_resize: could not read export settings; skipping.",
+            exc_info=True,
+        )
+        return image
+
+    if not export_settings.get("limit_output_width", False):
+        logger.debug("apply_width_limit_resize: feature disabled, skipping.")
+        return image
+
+    target_width = int(export_settings.get("output_width_limit", 0))
+    if target_width <= 0:
+        logger.warning(
+            "apply_width_limit_resize: target_width=%d is invalid, skipping.",
+            target_width,
+        )
+        return image
+
+    h, w = image.shape[:2]
+    if w == target_width:
+        logger.info(
+            "apply_width_limit_resize: image width %d already matches target, no resize needed.",
+            w,
+        )
+        return image
+
+    ratio = target_width / w
+    new_w = target_width
+    new_h = int(h * ratio + 0.5)
+
+    logger.info(
+        "apply_width_limit_resize: resizing (%d, %d) -> (%d, %d) [target_width=%d, ratio=%.4f]",
+        w, h, new_w, new_h, target_width, ratio,
+    )
+
+    resized = imk.resize(image, (new_w, new_h), mode=Image.Resampling.BICUBIC)
+    return resized

--- a/pipeline/inpainting.py
+++ b/pipeline/inpainting.py
@@ -23,6 +23,9 @@ class InpaintingHandler:
     def _ensure_inpainter(self):
         settings_page = self.main_page.settings_page
         inpainter_key = settings_page.get_tool_selection('inpainter')
+        # Fall back to AOT if the saved selection is empty or no longer available
+        if not inpainter_key or inpainter_key not in inpaint_map:
+            inpainter_key = "AOT"
         if self.inpainter_cache is None or self.cached_inpainter_key != inpainter_key:
             backend = get_inpainter_backend(inpainter_key)
             device = resolve_device(settings_page.is_gpu_enabled(), backend)

--- a/pipeline/webtoon_batch/chunk.py
+++ b/pipeline/webtoon_batch/chunk.py
@@ -66,6 +66,9 @@ class ChunkMixin:
     def _ensure_inpainter(self: WebtoonBatchProcessor):
         settings_page = self.main_page.settings_page
         inpainter_key = settings_page.get_tool_selection("inpainter")
+        # Fall back to AOT if the saved selection is empty or no longer available
+        if not inpainter_key or inpainter_key not in inpaint_map:
+            inpainter_key = "AOT"
         if (
             self.inpainting.inpainter_cache is None
             or self.inpainting.cached_inpainter_key != inpainter_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pyclipper>=1.3.0.post6
 six>=1.16.0
 PhotoshopAPI>=0.9.0
 send2trash>=2.1.0
+gdown>=5.0.0


### PR DESCRIPTION
Introduce a full Tool Presets workflow for typesetting, including preset persistence, preset management UI, and controller wiring into the main workspace.

Extend model support with YOLOv8 detection, Manga OCR 2025 (Torch and ONNX engines), LaMa Large, and CUHK Manga Inpainting integrations, plus model registration/download plumbing.

Improve runtime stability and quality by hardening ONNX provider selection, adding fallback handling for invalid saved inpainters, and fixing RESIZE-strategy compositing so masked blending happens at full resolution.

Add export/save output sizing controls, including post-render HD resize and optional width-limit resizing, and wire these settings across single-image save and batch export paths.

Also adds gdown dependency required for automatic Manga Inpainting checkpoint downloads from Google Drive.