### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/app/ui/settings/credentials_page.py
+++ b/app/ui/settings/credentials_page.py
@@ -113,6 +113,27 @@ class CredentialsPage(QtWidgets.QWidget):
                 service_layout.addWidget(model_input)
                 self.credential_widgets[f"{normalized}_model"] = model_input
 
+            elif normalized == "LiteLLM":
+                api_key_input = MLineEdit()
+                api_key_input.setEchoMode(QtWidgets.QLineEdit.Password)
+                api_key_input.setFixedWidth(400)
+                api_key_prefix = MLabel(self.tr("API Key")).border()
+                set_label_width(api_key_prefix)
+                api_key_prefix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                api_key_input.set_prefix_widget(api_key_prefix)
+                service_layout.addWidget(api_key_input)
+                self.credential_widgets[f"{normalized}_api_key"] = api_key_input
+
+                model_input = MLineEdit()
+                model_input.setFixedWidth(400)
+                model_prefix = MLabel(self.tr("Model")).border()
+                set_label_width(model_prefix)
+                model_prefix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                model_input.set_prefix_widget(model_prefix)
+                model_input.setPlaceholderText("e.g. anthropic/claude-sonnet-4-6")
+                service_layout.addWidget(model_input)
+                self.credential_widgets[f"{normalized}_model"] = model_input
+
             elif normalized == "Yandex":
                 api_key_input = MLineEdit()
                 api_key_input.setEchoMode(QtWidgets.QLineEdit.Password)

--- a/app/ui/settings/settings_page.py
+++ b/app/ui/settings/settings_page.py
@@ -100,7 +100,7 @@ class SettingsPage(QtWidgets.QWidget):
 
     def _sync_extra_context_limit(self, translator: str) -> None:
         normalized = self.ui.reverse_mappings.get(translator, translator)
-        self.ui.llms_page.set_extra_context_unlimited(normalized == "Custom")
+        self.ui.llms_page.set_extra_context_unlimited(normalized in ("Custom", "LiteLLM"))
 
     def on_theme_changed(self, theme: str):
         self.theme_changed.emit(theme)
@@ -168,6 +168,9 @@ class SettingsPage(QtWidgets.QWidget):
             if normalized == "Custom":
                 for field in ("api_key", "api_url", "model"):
                     creds[field] = _text_or_none(f"Custom_{field}")
+            elif normalized == "LiteLLM":
+                for field in ("api_key", "model"):
+                    creds[field] = _text_or_none(f"LiteLLM_{field}")
 
             return creds
 
@@ -310,6 +313,9 @@ class SettingsPage(QtWidgets.QWidget):
                     settings.setValue(f"{translated_service}_api_key", cred['api_key'])
                     settings.setValue(f"{translated_service}_api_url", cred['api_url'])
                     settings.setValue(f"{translated_service}_model", cred['model'])
+                elif translated_service == "LiteLLM":
+                    settings.setValue(f"{translated_service}_api_key", cred['api_key'])
+                    settings.setValue(f"{translated_service}_model", cred['model'])
         else:
             settings.remove('credentials')  # Clear all credentials if save_keys is unchecked
         settings.endGroup()
@@ -429,6 +435,9 @@ class SettingsPage(QtWidgets.QWidget):
                 if translated_service == "Custom":
                     self.ui.credential_widgets[f"{translated_service}_api_key"].setText(settings.value(f"{translated_service}_api_key", ''))
                     self.ui.credential_widgets[f"{translated_service}_api_url"].setText(settings.value(f"{translated_service}_api_url", ''))
+                    self.ui.credential_widgets[f"{translated_service}_model"].setText(settings.value(f"{translated_service}_model", ''))
+                elif translated_service == "LiteLLM":
+                    self.ui.credential_widgets[f"{translated_service}_api_key"].setText(settings.value(f"{translated_service}_api_key", ''))
                     self.ui.credential_widgets[f"{translated_service}_model"].setText(settings.value(f"{translated_service}_model", ''))
         settings.endGroup()
 

--- a/app/ui/settings/settings_ui.py
+++ b/app/ui/settings/settings_ui.py
@@ -65,7 +65,8 @@ class SettingsPageUI(QtWidgets.QWidget):
         self.alignment = [self.tr("Left"), self.tr("Center"), self.tr("Right")]
 
         self.credential_services = [
-            self.tr("Custom"), 
+            self.tr("Custom"),
+            self.tr("LiteLLM"),
         ]
         
         self.supported_translators = [
@@ -75,6 +76,7 @@ class SettingsPageUI(QtWidgets.QWidget):
             self.tr("Claude-4.6-Sonnet"),
             self.tr("Claude-4.5-Haiku"),
             self.tr("Deepseek"),
+            self.tr("LiteLLM"),
             self.tr("Custom"),
         ]
         
@@ -154,6 +156,7 @@ class SettingsPageUI(QtWidgets.QWidget):
             self.tr("DeepL"): "DeepL",
             self.tr("Anthropic Claude"): "Anthropic Claude",
             self.tr("Yandex"): "Yandex",
+            self.tr("LiteLLM"): "LiteLLM",
         }
 
         # Create reverse mappings for loading

--- a/modules/translation/factory.py
+++ b/modules/translation/factory.py
@@ -10,6 +10,7 @@ from .llm.claude import ClaudeTranslation
 from .llm.gemini import GeminiTranslation
 from .llm.deepseek import DeepseekTranslation
 from .llm.custom import CustomTranslation
+from .llm.litellm import LiteLLMTranslation
 from .user import UserTranslator
 from app.account.auth.token_storage import get_token
 
@@ -32,7 +33,8 @@ class TranslationFactory:
         "Claude": ClaudeTranslation,
         "Gemini": GeminiTranslation,
         "Deepseek": DeepseekTranslation,
-        "Custom": CustomTranslation
+        "Custom": CustomTranslation,
+        "LiteLLM": LiteLLMTranslation
     }
     
     DEFAULT_LLM_ENGINE = GPTTranslation
@@ -78,7 +80,7 @@ class TranslationFactory:
         """Get the appropriate engine class based on translator key."""
 
         access_token = get_token("access_token")
-        if access_token and translator_key not in ['Custom']:
+        if access_token and translator_key not in ['Custom', 'LiteLLM']:
             return UserTranslator
 
         # First check if it's a traditional translation engine (exact match)

--- a/modules/translation/llm/litellm.py
+++ b/modules/translation/llm/litellm.py
@@ -1,0 +1,84 @@
+from typing import Any
+import numpy as np
+
+from .base import BaseLLMTranslation
+
+
+class LiteLLMTranslation(BaseLLMTranslation):
+    """Translation engine using LiteLLM as a unified AI gateway.
+
+    Supports 100+ LLM providers (OpenAI, Anthropic, Google, Azure,
+    AWS Bedrock, Ollama, and more) through a single interface.
+    Users specify a LiteLLM model string such as
+    ``anthropic/claude-sonnet-4-6`` or ``openai/gpt-4.1``.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.supports_images = True
+
+    def initialize(self, settings: Any, source_lang: str, target_lang: str,
+                   tr_key: str = "LiteLLM", **kwargs) -> None:
+        super().initialize(settings, source_lang, target_lang, **kwargs)
+
+        credentials = settings.get_credentials(settings.ui.tr(tr_key))
+        self.api_key = credentials.get('api_key', '')
+        self.model = credentials.get('model', '')
+        self.timeout = 120
+
+    def _perform_translation(self, user_prompt: str, system_prompt: str,
+                             image: np.ndarray) -> str:
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "The 'litellm' package is required for LiteLLM translations. "
+                "Install it with: pip install litellm"
+            )
+
+        if self.supports_images and self.img_as_llm_input and image is not None:
+            encoded_image, mime_type = self.encode_image(image)
+            messages = [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": system_prompt}]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": user_prompt},
+                        {"type": "image_url", "image_url": {
+                            "url": f"data:{mime_type};base64,{encoded_image}"
+                        }}
+                    ]
+                }
+            ]
+        else:
+            messages = [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": system_prompt}]
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": user_prompt}]
+                }
+            ]
+
+        kwargs = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            "drop_params": True,
+            "timeout": self.timeout,
+        }
+
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+
+        try:
+            response = litellm.completion(**kwargs)
+            return response.choices[0].message.content
+        except Exception as e:
+            raise RuntimeError(f"LiteLLM API request failed: {e}")

--- a/modules/translation/llm/litellm.py
+++ b/modules/translation/llm/litellm.py
@@ -1,5 +1,6 @@
 from typing import Any
 import numpy as np
+import litellm
 
 from .base import BaseLLMTranslation
 
@@ -28,14 +29,6 @@ class LiteLLMTranslation(BaseLLMTranslation):
 
     def _perform_translation(self, user_prompt: str, system_prompt: str,
                              image: np.ndarray) -> str:
-        try:
-            import litellm
-        except ImportError:
-            raise ImportError(
-                "The 'litellm' package is required for LiteLLM translations. "
-                "Install it with: pip install litellm"
-            )
-
         if self.supports_images and self.img_as_llm_input and image is not None:
             encoded_image, mime_type = self.encode_image(image)
             messages = [

--- a/modules/translation/processor.py
+++ b/modules/translation/processor.py
@@ -65,7 +65,8 @@ class Translator:
             self.settings.ui.tr("Gemini-2.5-Pro"): "Gemini-2.5-Pro",
             self.settings.ui.tr("Microsoft Translator"): "Microsoft Translator",
             self.settings.ui.tr("DeepL"): "DeepL",
-            self.settings.ui.tr("Yandex"): "Yandex"
+            self.settings.ui.tr("Yandex"): "Yandex",
+            self.settings.ui.tr("LiteLLM"): "LiteLLM"
         }
         return translator_map.get(localized_translator, localized_translator)
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ six>=1.16.0
 PhotoshopAPI>=0.9.0
 send2trash>=2.1.0
 PyJWT>=2.8.0
+litellm


### PR DESCRIPTION


## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a translation provider, giving users access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, AWS Bedrock, Ollama, Groq, Mistral, DeepSeek, and more) through a single integration
- Users specify a LiteLLM model string like `anthropic/claude-sonnet-4-6` or `openai/gpt-4.1` - LiteLLM handles routing and API differences automatically

## Motivation
The Custom provider works for strictly OpenAI-compatible APIs but breaks when providers return slightly different response formats or require different auth headers. LiteLLM normalizes these differences at the SDK level, giving users reliable access to any provider without debugging API quirks.

This also benefits users who want to use local models (Ollama), enterprise endpoints (Azure, Bedrock), or cost-optimized providers (Groq, Together) without needing to run a separate proxy.

## Changes
- `modules/translation/llm/litellm.py` - New `LiteLLMTranslation` provider extending `BaseLLMTranslation`, uses `litellm.completion()` with `drop_params=True` for cross-provider compatibility
- `requirements.txt` - Added `litellm` dependency
- `modules/translation/factory.py` - Registered in `LLM_ENGINE_IDENTIFIERS`, exempted from `UserTranslator` bypass (same as Custom)
- `modules/translation/processor.py` - Added translator key mapping
- `app/ui/settings/settings_ui.py` - Added to translator dropdown, value mappings, and credential services
- `app/ui/settings/credentials_page.py` - Added credential fields (API Key + Model with placeholder example)
- `app/ui/settings/settings_page.py` - Added credential save/load handling, unlimited extra context support

## Tests

**Live E2E test** - Japanese-to-English translation via Anthropic Claude through LiteLLM:
```
Input:  {"block_0": "こんにちは世界"}
Model:  anthropic/claude-sonnet-4-6

Response: {"block_0": "Hello World"}
```

The full chain works: `LiteLLMTranslation._perform_translation()` -> `litellm.completion()` -> Anthropic API -> response parsed back as translated JSON.

**Integration details:**
- `litellm` is added to `requirements.txt` and imported at module level
- `drop_params=True` silently drops provider-unsupported kwargs (e.g., `top_p` on some Anthropic models, `seed` on non-OpenAI providers)
- API key is passed via kwargs when set, omitted when blank so LiteLLM falls back to provider env vars (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`)
- Supports multimodal image input for vision-capable models

## Risk / Compatibility
- Additive only - existing providers untouched
- `litellm` added to `requirements.txt`
- Follows the exact same pattern as the existing Custom provider

## Example usage
1. In Comic Translate settings, select **LiteLLM** as translator
3. Go to Advanced > Credentials > LiteLLM
4. Enter your model string (e.g., `anthropic/claude-sonnet-4-6`, `openai/gpt-4.1`, `groq/llama-4-scout-17b-16e-instruct`)
5. Enter your API key (or leave blank if set via environment variable)
6. Translate as usual

```python
# Under the hood, the provider does:
import litellm

response = litellm.completion(
    model="anthropic/claude-sonnet-4-6",  # any of 100+ providers
    messages=[
        {"role": "system", "content": [{"type": "text", "text": "You are an expert translator..."}]},
        {"role": "user", "content": [{"type": "text", "text": '{"block_0": "こんにちは世界"}'}]}
    ],
    temperature=1.0,
    max_tokens=5000,
    drop_params=True,
    api_key="your-api-key",
)
# Returns: {"block_0": "Hello World"}
```
